### PR TITLE
feat: real multi-tenancy

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -67,3 +67,11 @@ XOLO_PLUGINS_DIR=bin/plugins
 # XOLO_PROVISIONNING_API_TLS_KEY_FILE=dev-pki/server.key
 # XOLO_PROVISIONNING_API_TLS_CLIENT_CA_FILE=dev-pki/ca.crt
 # XOLO_PROVISIONNING_API_SHUTDOWN_TIMEOUT=10s
+
+# Multi-tenancy. Disabled by default: the instance owns a single tenant, created
+# by the schema migration and never surfaced to its users — no subdomain, no
+# change of URL. Once enabled, the tenant is read from the request host and a
+# host matching no tenant answers 404.
+# XOLO_MULTITENANCY_ENABLED=true
+# XOLO_MULTITENANCY_HOST_PATTERN={tenant}.xolo.example.com
+# XOLO_MULTITENANCY_DEFAULT_TENANT_SLUG=default

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ Xolo is an enterprise LLM gateway. It wraps the `github.com/bornholm/genai/proxy
 ```
 internal/
   core/
-    model/      — domain types: User, AuthToken, Task
-    port/       — interfaces: UserStore, TaskRunner, error sentinels
+    model/      — domain types: Tenant, Organization, User, AuthToken, Task
+    port/       — interfaces: TenantStore, UserStore, TaskRunner, error sentinels
     service/    — orchestration across stores (QuotaService, ProvisioningService)
   provisionning/ — instance provisionning API: own listener, own port, mutual TLS
-    handler/v1/ — versioned M2M REST API (tenants, members, roles, users)
+    handler/v1/ — versioned M2M REST API (tenants > organizations > members/roles, tenant users)
   adapter/
     gorm/       — GORM implementation of the stores (SQLite or PostgreSQL, see internal/adapter/gorm/dialect.go)
                   store tests go through eachBackend() so every behaviour is asserted on both backends
@@ -47,8 +47,9 @@ internal/
   http/
     server.go   — HTTP server (CORS, slog middleware, context injection)
     options.go  — mount points configuration
-    context/    — request-scoped values (BaseURL, CurrentURL, User)
+    context/    — request-scoped values (BaseURL, CurrentURL, Tenant, User)
     middleware/
+      tenant/   — resolves the request tenant (subdomain in multi-tenant mode); runs before everything else
       authn/    — authentication: OIDC (goth) + token-based
       authz/    — role assertions (user/admin/active)
       bridge/   — populates/creates User from authn identity
@@ -73,12 +74,30 @@ internal/
 - The genai proxy is mounted at `/v1/` and sits behind auth middleware
 - `cmd/server` runs the public HTTP server and, when enabled, the Provisionning API server on the same root context; the first fatal error stops both
 
+### Multi-tenancy
+
+A **Tenant** owns organizations and users; it is the outermost isolation
+boundary. Slugs and identities are unique per tenant, never instance-wide:
+`GetOrgBySlug`, `GetUserByIdentity` and `FindOrCreateUser` all take a
+`model.TenantID`, and `ListOrgsOptions`/`QueryUsersOptions` carry a `TenantID`
+filter. Xolo IDs stay globally unique, so lookups by ID keep their signature —
+the tenant is then asserted by the service layer.
+
+Disabled by default: the schema migration creates a single `default` tenant,
+attaches every pre-existing row to it, and the tenant is never surfaced (no
+subdomain, no change of URL). `XOLO_MULTITENANCY_ENABLED=true` plus
+`XOLO_MULTITENANCY_HOST_PATTERN={tenant}.example.com` switches the resolution to
+the request host; a host matching no active tenant answers 404.
+See `internal/http/middleware/tenant/`.
+
 ### Provisionning API
 
-Machine-to-machine provisioning of tenants, members, roles and users, on a
-dedicated listener authenticated by mutual TLS only (`XOLO_PROVISIONNING_API_*`,
-disabled by default). It never grants platform-wide privileges and shares the
-same store instances as the public server. See `internal/provisionning/README.md`.
+Machine-to-machine provisioning of tenants, the organizations they own, their
+members, roles and users, on a dedicated listener authenticated by mutual TLS
+only (`XOLO_PROVISIONNING_API_*`, disabled by default). It never grants
+platform-wide privileges and shares the same store instances as the public
+server. Creating a second tenant is refused while multi-tenancy is disabled.
+See `internal/provisionning/README.md`.
 
 ### UI / templating
 

--- a/cmd/seed/fixtures.go
+++ b/cmd/seed/fixtures.go
@@ -88,6 +88,11 @@ type seeder struct {
 
 	usageRecords int
 	usageCost    map[string]int64 // orgID -> total cost (microcents, org currency)
+
+	// tenantID is the default tenant, created by the schema migration. The
+	// fixture is single-tenant: everything hangs from it, exactly like an
+	// instance running with multi-tenancy disabled.
+	tenantID string
 }
 
 func newRand(seed int64) *rand.Rand {
@@ -101,6 +106,7 @@ func (s *seeder) seed(ctx context.Context) error {
 		name string
 		fn   func(ctx context.Context) error
 	}{
+		{"tenant", s.resolveTenant},
 		{"organizations", s.seedOrganizations},
 		{"users", s.seedUsers},
 		{"roles", s.seedRoles},
@@ -136,6 +142,19 @@ func (s *seeder) create(records ...any) error {
 			return errors.WithStack(err)
 		}
 	}
+	return nil
+}
+
+// resolveTenant reads the tenant every fixture belongs to. It is created by the
+// schema migration, which has already run by the time the seeder starts.
+func (s *seeder) resolveTenant(ctx context.Context) error {
+	tenant, err := s.store.GetTenantBySlug(ctx, model.DefaultTenantSlug)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	s.tenantID = string(tenant.ID())
+
 	return nil
 }
 
@@ -175,6 +194,8 @@ func (s *seeder) seedOrganizations(ctx context.Context) error {
 	}
 
 	for _, org := range orgs {
+		org.TenantID = s.tenantID
+
 		if err := s.create(org); err != nil {
 			return errors.WithStack(err)
 		}
@@ -264,6 +285,8 @@ func (s *seeder) seedUsers(ctx context.Context) error {
 	}
 
 	for _, user := range users {
+		user.TenantID = s.tenantID
+
 		roles := user.Roles
 		prefs := user.Preferences
 		user.Roles = nil

--- a/docs/fr/administration/provisioning/provisioning.md
+++ b/docs/fr/administration/provisioning/provisioning.md
@@ -1,6 +1,6 @@
 # API de provisioning
 
-L'API de provisioning (*Provisionning API*) permet à un système externe — plan de contrôle, opérateur Kubernetes, provider Terraform, playbook Ansible ou simple script — de créer et de réconcilier les organisations, les membres et les rôles d'une instance Xolo **sans aucune interaction humaine**.
+L'API de provisioning (*Provisionning API*) permet à un système externe — plan de contrôle, opérateur Kubernetes, provider Terraform, playbook Ansible ou simple script — de créer et de réconcilier les tenants, les organisations, les membres et les rôles d'une instance Xolo **sans aucune interaction humaine**.
 
 Elle ne fait délibérément pas partie de l'API `/api/v1/` utilisée par l'interface web : son périmètre de sécurité est différent (privilèges à l'échelle de l'instance, aucun contexte utilisateur). Elle dispose donc de son propre écouteur, sur son propre port, avec sa propre configuration TLS et son propre mécanisme d'authentification.
 
@@ -12,7 +12,9 @@ Processus Xolo
 
 Les deux serveurs partagent les **mêmes instances de stockage** (caches et décorateurs d'événements compris) : aucune seconde connexion à la base de données.
 
-> **Vocabulaire.** L'API parle de `tenant` là où le reste de Xolo parle d'organisation. Il s'agit du même objet.
+> **Hiérarchie.** Un **tenant** contient des **organisations**, qui contiennent des **membres** et des **rôles**. Les utilisateurs appartiennent au tenant, pas à l'organisation : le couple `(provider, subject)` n'est unique qu'au sein d'un tenant, si bien qu'une même personne connectée sur deux tenants dispose de deux comptes distincts.
+>
+> Par défaut, une instance ne possède qu'un seul tenant, `default`, créé automatiquement à la migration. Il est invisible pour les utilisateurs — aucun sous-domaine, aucune URL modifiée — mais c'est lui qui fournit le `{tenantID}` attendu par les routes ci-dessous.
 
 ## Authentification : TLS mutuel
 
@@ -35,6 +37,14 @@ Le matériel TLS est chargé au démarrage : un certificat, une clé ou un bundl
 | `XOLO_PROVISIONNING_API_TLS_CLIENT_CA_FILE` | _(requis si activé)_ | Autorité vérifiant les certificats clients. |
 | `XOLO_PROVISIONNING_API_SHUTDOWN_TIMEOUT` | `10s` | Délai d'arrêt gracieux. |
 
+Le multi-tenant se configure au niveau de l'instance, pas de cette API :
+
+| Variable | Défaut | Description |
+| --- | --- | --- |
+| `XOLO_MULTITENANCY_ENABLED` | `false` | Autorise plus d'un tenant. |
+| `XOLO_MULTITENANCY_HOST_PATTERN` | _(requis si activé)_ | Modèle de nom d'hôte, par exemple `{tenant}.xolo.example.com`. |
+| `XOLO_MULTITENANCY_DEFAULT_TENANT_SLUG` | `default` | Tenant servi lorsque le multi-tenant est désactivé. |
+
 N'exposez pas ce port sur un réseau public : réservez-le au réseau d'administration ou au maillage de services interne.
 
 ## Endpoints
@@ -44,24 +54,40 @@ N'exposez pas ce port sur un réseau public : réservez-le au réseau d'administ
 | `GET` | `/v1/healthz` | Également derrière TLS mutuel. |
 | `GET` | `/v1/permissions` | Catalogue RBAC : seule source des codes de permission valides. |
 | `GET` | `/v1/tenants` | `?slug=` pour une recherche exacte, sinon `?page=&limit=`. |
-| `POST` | `/v1/tenants` | Crée l'organisation, ses rôles intégrés et, optionnellement, son propriétaire initial. |
+| `POST` | `/v1/tenants` | **Refusé avec `409` sur une instance mono-tenant.** |
 | `GET` | `/v1/tenants/{tenantID}` | |
-| `PATCH` | `/v1/tenants/{tenantID}` | `name`, `description`, `active`, `currency`, `shareQuotaEqually`. Le slug est immuable. |
-| `DELETE` | `/v1/tenants/{tenantID}` | Supprime l'organisation et toutes ses données. |
-| `GET` | `/v1/tenants/{tenantID}/members` | Paginé. |
-| `POST` | `/v1/tenants/{tenantID}/members` | `userId` **ou** `user{provider,subject,…}`, plus `roleIds[]` et/ou `builtinRoles[]`. |
-| `GET` | `/v1/tenants/{tenantID}/members/{membershipID}` | |
-| `PUT` | `/v1/tenants/{tenantID}/members/{membershipID}/roles` | Remplacement complet du jeu de rôles. |
-| `DELETE` | `/v1/tenants/{tenantID}/members/{membershipID}` | |
-| `GET` | `/v1/tenants/{tenantID}/roles` | Rôles intégrés et personnalisés. |
-| `POST` | `/v1/tenants/{tenantID}/roles` | Rôle personnalisé. |
-| `GET` | `/v1/tenants/{tenantID}/roles/{roleID}` | |
-| `PUT` | `/v1/tenants/{tenantID}/roles/{roleID}` | Rôles personnalisés uniquement. |
-| `DELETE` | `/v1/tenants/{tenantID}/roles/{roleID}` | Rôles personnalisés uniquement. |
-| `GET` | `/v1/users` | `?provider=&subject=` pour une recherche exacte, sinon `?search=&active=&page=&limit=`. |
-| `PUT` | `/v1/users` | Upsert idempotent sur `(provider, subject)` : `201` à la création, `200` sinon. |
-| `GET` | `/v1/users/{userID}` | |
-| `PATCH` | `/v1/users/{userID}` | `email`, `displayName`, `active`. |
+| `PATCH` | `/v1/tenants/{tenantID}` | `name`, `description`, `active`. Le slug est immuable. |
+| `DELETE` | `/v1/tenants/{tenantID}` | Supprime le tenant et tout ce qu'il contient. |
+| `GET` | `/v1/tenants/{tenantID}/organizations` | `?slug=` pour une recherche exacte, sinon `?page=&limit=`. |
+| `POST` | `/v1/tenants/{tenantID}/organizations` | Crée l'organisation, ses rôles intégrés et, optionnellement, son propriétaire initial. |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}` | |
+| `PATCH` | `/v1/tenants/{tenantID}/organizations/{orgID}` | `name`, `description`, `active`, `currency`, `shareQuotaEqually`. Le slug est immuable. |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}` | Supprime l'organisation et toutes ses données. |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/members` | Paginé. |
+| `POST` | `/v1/tenants/{tenantID}/organizations/{orgID}/members` | `userId` **ou** `user{provider,subject,…}`, plus `roleIds[]` et/ou `builtinRoles[]`. |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}` | |
+| `PUT` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}/roles` | Remplacement complet du jeu de rôles. |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}` | |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles` | Rôles intégrés et personnalisés. |
+| `POST` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles` | Rôle personnalisé. |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | |
+| `PUT` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | Rôles personnalisés uniquement. |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | Rôles personnalisés uniquement. |
+| `GET` | `/v1/tenants/{tenantID}/users` | `?provider=&subject=` pour une recherche exacte, sinon `?search=&active=&page=&limit=`. |
+| `PUT` | `/v1/tenants/{tenantID}/users` | Upsert idempotent sur `(provider, subject)` : `201` à la création, `200` sinon. |
+| `GET` | `/v1/tenants/{tenantID}/users/{userID}` | |
+| `PATCH` | `/v1/tenants/{tenantID}/users/{userID}` | `email`, `displayName`, `active`. |
+
+### Instances mono-tenant
+
+Sur une installation par défaut, commencez par récupérer l'identifiant du tenant unique :
+
+```bash
+curl -s --cacert dev-pki/ca.crt --cert dev-pki/client.crt --key dev-pki/client.key \
+  "https://localhost:3003/v1/tenants?slug=default"
+```
+
+Toutes les routes ci-dessus s'utilisent ensuite avec cet identifiant. La création d'un second tenant est refusée avec `409` tant que `XOLO_MULTITENANCY_ENABLED` vaut `false` : aucun nom d'hôte ne permettrait de l'atteindre, ses organisations seraient donc inaccessibles.
 
 Les charges utiles sont en JSON *camelCase*, les horodatages au format RFC 3339, et les collections sont renvoyées sous la forme `{"items": […], "page": 1, "limit": 50, "total": 123}`. Les champs inconnus sont rejetés : un nom de champ mal orthographié est signalé plutôt qu'ignoré silencieusement.
 
@@ -70,14 +96,14 @@ Les charges utiles sont en JSON *camelCase*, les horodatages au format RFC 3339,
 Toutes les erreurs utilisent la même enveloppe :
 
 ```json
-{"error": {"code": "conflict", "message": "tenant with slug \"acme\" already exists (id: c9m2…)"}}
+{"error": {"code": "conflict", "message": "organization with slug \"acme\" already exists in this tenant (id: c9m2…)"}}
 ```
 
 | Code | HTTP | Cause |
 | --- | --- | --- |
 | `invalid_request` | 400 | Corps mal formé, champ inconnu, paramètre de requête invalide. |
 | `unauthorized` | 401 | Aucun certificat client vérifié. |
-| `not_found` | 404 | Ressource inconnue, ou appartenant à une autre organisation. |
+| `not_found` | 404 | Ressource inconnue, ou appartenant à un autre tenant ou à une autre organisation. |
 | `method_not_allowed` | 405 | Ressource connue, mauvaise méthode. |
 | `conflict` | 409 | Ressource existante, ou invariant métier qui refuse la modification. |
 | `unprocessable` | 422 | Valeur bien formée mais refusée par le domaine. |
@@ -91,9 +117,9 @@ Un utilisateur est identifié par le couple `provider` + `subject`, la même cl�
 
 ### Provisionner avant la première connexion
 
-`POST /v1/tenants` crée son propriétaire avant même que cette personne ne se connecte. Cela suppose que l'appelant connaisse son `subject` à l'avance, ce qui est le cas lorsque le plan de contrôle pilote aussi le fournisseur d'identité, ou lorsque le sujet est dérivé de façon déterministe.
+`POST /v1/tenants/{tenantID}/organizations` crée son propriétaire avant même que cette personne ne se connecte. Cela suppose que l'appelant connaisse son `subject` à l'avance, ce qui est le cas lorsque le plan de contrôle pilote aussi le fournisseur d'identité, ou lorsque le sujet est dérivé de façon déterministe.
 
-Lorsque le sujet ne peut pas être connu à l'avance, ne désactivez pas `XOLO_HTTP_AUTHN_AUTO_CREATE_USERS` : les personnes concernées ne pourraient plus se connecter. Utilisez plutôt `XOLO_HTTP_AUTHN_ACTIVE_BY_DEFAULT=false`. Le compte est alors créé à la première connexion mais reste inactif et n'accorde aucun droit. Le plan de contrôle le récupère avec `GET /v1/users?active=false`, le rattache à une organisation via `POST /v1/tenants/{tenantID}/members`, puis l'active avec `PATCH /v1/users/{userID} {"active": true}`.
+Lorsque le sujet ne peut pas être connu à l'avance, ne désactivez pas `XOLO_HTTP_AUTHN_AUTO_CREATE_USERS` : les personnes concernées ne pourraient plus se connecter. Utilisez plutôt `XOLO_HTTP_AUTHN_ACTIVE_BY_DEFAULT=false`. Le compte est alors créé à la première connexion mais reste inactif et n'accorde aucun droit. Le plan de contrôle le récupère avec `GET /v1/tenants/{tenantID}/users?active=false`, le rattache à une organisation via `POST /v1/tenants/{tenantID}/organizations/{orgID}/members`, puis l'active avec `PATCH /v1/tenants/{tenantID}/users/{userID} {"active": true}`.
 
 ## Invariants
 
@@ -101,13 +127,14 @@ Lorsque le sujet ne peut pas être connu à l'avance, ne désactivez pas `XOLO_H
 - Les adresses listées dans `XOLO_HTTP_AUTHN_DEFAULT_ADMINS` sont **réservées** : l'API refuse (`422`) de les affecter à un utilisateur, faute de quoi ce dernier deviendrait administrateur plateforme à sa prochaine connexion.
 - Une organisation conserve toujours au moins un propriétaire : retirer ou rétrograder le dernier est refusé avec un `409`.
 - Un rôle ne peut être affecté qu'à un membre de l'organisation à laquelle il appartient. Tout autre cas donne un `422`, sans qu'aucun rôle ne soit modifié.
-- Un membre ou un rôle appartenant à une autre organisation est signalé comme `404`.
+- Un membre ou un rôle appartenant à une autre organisation est signalé comme `404`, tout comme une organisation ou un utilisateur appartenant à un autre tenant.
+- Le tenant `default` ne peut être ni supprimé ni désactivé : c'est celui vers lequel toute instance mono-tenant se rabat.
 - Les rôles intégrés ne peuvent être ni modifiés, ni supprimés.
 - Seuls les codes de permission présents dans le catalogue RBAC sont acceptés.
 
 ## Réconciliation
 
-Les identifiants sont stables, `PUT /v1/users` est idempotent, `POST /v1/tenants` sur un slug existant répond `409` en incluant l'identifiant existant, et les endpoints de lecture permettent de relire l'état courant intégralement. Le seul effet de bord de `POST /v1/tenants` est documenté : la création des rôles intégrés de l'organisation.
+Les identifiants sont stables, `PUT /v1/tenants/{tenantID}/users` est idempotent, la création d'un tenant ou d'une organisation sur un slug existant répond `409` en incluant l'identifiant existant, et les endpoints de lecture permettent de relire l'état courant intégralement. Le seul effet de bord de `POST /v1/tenants/{tenantID}/organizations` est documenté : la création des rôles intégrés de l'organisation.
 
 La création d'une organisation orchestre plusieurs magasins de données sans transaction transverse. Tout échec survenant après la création de la ligne d'organisation déclenche une compensation au mieux (l'organisation est supprimée, les rattachements suivent en cascade), journalisée si elle échoue à son tour. Un utilisateur préexistant n'est jamais supprimé.
 
@@ -149,12 +176,17 @@ bin/server
 Premiers appels :
 
 ```bash
+CURL="curl -s --cacert dev-pki/ca.crt --cert dev-pki/client.crt --key dev-pki/client.key"
+
 # Refusé : aucun certificat client
 curl -sk https://localhost:3003/v1/permissions
 
-# Accepté
-curl -s --cacert dev-pki/ca.crt --cert dev-pki/client.crt --key dev-pki/client.key \
-  -X POST https://localhost:3003/v1/tenants \
+# Accepté : on récupère d'abord l'identifiant du tenant
+$CURL "https://localhost:3003/v1/tenants?slug=default"
+TENANT=…  # l'identifiant lu ci-dessus
+
+# Puis on crée une organisation et son propriétaire
+$CURL -X POST "https://localhost:3003/v1/tenants/$TENANT/organizations" \
   -d '{"slug":"acme","name":"Acme","owner":{"provider":"openid-connect","subject":"sub-123","email":"owner@acme.tld","displayName":"Owner"}}'
 ```
 

--- a/docs/fr/concepts/organisation-et-permissions.md
+++ b/docs/fr/concepts/organisation-et-permissions.md
@@ -6,6 +6,16 @@ L'**organisation** est l'entité centrale de Xolo : elle regroupe des **membres*
 
 Un même utilisateur peut appartenir à plusieurs organisations ; il bascule de l'une à l'autre depuis le menu de l'interface.
 
+## Le tenant
+
+Au-dessus de l'organisation se trouve le **tenant**, la frontière d'isolation la plus externe : il possède des organisations et des utilisateurs. Rien ne franchit cette frontière — ni un compte, ni un jeton d'API, ni une session.
+
+**Vous n'avez normalement pas à vous en soucier.** Par défaut, Xolo fonctionne avec un tenant unique nommé `default`, créé automatiquement : aucun sous-domaine n'est nécessaire, aucune URL ne change, et le tenant n'apparaît nulle part dans l'interface.
+
+Il ne devient visible que sur une instance mutualisée, où plusieurs clients cohabitent. Le multi-tenant s'active alors par configuration (`XOLO_MULTITENANCY_ENABLED`), et chaque tenant est identifié par son sous-domaine selon un modèle configurable, par exemple `acme.xolo.example.com`. Un sous-domaine qui ne correspond à aucun tenant actif renvoie une erreur 404.
+
+Deux tenants peuvent héberger une organisation portant le même slug, et une même identité peut y disposer de deux comptes distincts, sans aucune collision. La gestion des tenants passe exclusivement par l'[API de provisioning](../administration/provisioning/provisioning.md) ; il n'existe pas d'interface dédiée.
+
 ## Rôles
 
 Un **rôle** est un ensemble de permissions attribué à un ou plusieurs membres. Xolo distingue deux catégories de rôles :

--- a/internal/adapter/cache/cacheable_user.go
+++ b/internal/adapter/cache/cacheable_user.go
@@ -14,7 +14,7 @@ type CacheableUser struct {
 // CacheKeys implements [Cacheable].
 func (u *CacheableUser) CacheKeys() []string {
 	return []string{
-		getUserProviderSubjectCacheKey(u.Provider(), u.Subject()),
+		getUserProviderSubjectCacheKey(u.TenantID(), u.Provider(), u.Subject()),
 		string(u.ID()),
 	}
 }
@@ -28,8 +28,12 @@ var (
 	_ Cacheable  = &CacheableUser{}
 )
 
-func getUserProviderSubjectCacheKey(provider string, subject string) string {
-	return getCompositeCacheKey(provider, subject)
+// getUserProviderSubjectCacheKey keys the identity cache. The tenant is part of
+// the key because (provider, subject) is only unique within a tenant: without
+// it, the first tenant to resolve an identity would serve it to every other
+// one.
+func getUserProviderSubjectCacheKey(tenantID model.TenantID, provider string, subject string) string {
+	return getCompositeCacheKey(string(tenantID), provider, subject)
 }
 
 func getCompositeCacheKey(parts ...any) string {

--- a/internal/adapter/cache/user_store.go
+++ b/internal/adapter/cache/user_store.go
@@ -45,12 +45,12 @@ func (s *UserStore) FindAuthToken(ctx context.Context, token string) (model.Auth
 }
 
 // FindOrCreateUser implements [port.UserStore].
-func (s *UserStore) FindOrCreateUser(ctx context.Context, provider string, subject string) (model.User, error) {
-	if user, exists := s.userCache.Get(getUserProviderSubjectCacheKey(provider, subject)); exists {
+func (s *UserStore) FindOrCreateUser(ctx context.Context, tenantID model.TenantID, provider string, subject string) (model.User, error) {
+	if user, exists := s.userCache.Get(getUserProviderSubjectCacheKey(tenantID, provider, subject)); exists {
 		return user, nil
 	}
 
-	user, err := s.backend.FindOrCreateUser(ctx, provider, subject)
+	user, err := s.backend.FindOrCreateUser(ctx, tenantID, provider, subject)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +61,12 @@ func (s *UserStore) FindOrCreateUser(ctx context.Context, provider string, subje
 }
 
 // GetUserByIdentity implements [port.UserStore].
-func (s *UserStore) GetUserByIdentity(ctx context.Context, provider string, subject string) (model.User, error) {
-	if user, exists := s.userCache.Get(getUserProviderSubjectCacheKey(provider, subject)); exists {
+func (s *UserStore) GetUserByIdentity(ctx context.Context, tenantID model.TenantID, provider string, subject string) (model.User, error) {
+	if user, exists := s.userCache.Get(getUserProviderSubjectCacheKey(tenantID, provider, subject)); exists {
 		return user, nil
 	}
 
-	user, err := s.backend.GetUserByIdentity(ctx, provider, subject)
+	user, err := s.backend.GetUserByIdentity(ctx, tenantID, provider, subject)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/events/events_test.go
+++ b/internal/adapter/events/events_test.go
@@ -31,7 +31,7 @@ func newStore(t *testing.T) *xologorm.Store {
 }
 
 func withActor(ctx context.Context) context.Context {
-	user := model.NewUser("test", "sub-1", "u@example.com", "Alice", true, "user")
+	user := model.NewUser(testTenantID, "test", "sub-1", "u@example.com", "Alice", true, "user")
 	return httpCtx.SetUser(ctx, user)
 }
 
@@ -41,7 +41,7 @@ func TestProviderStore_EmitsWithActor(t *testing.T) {
 	store := eventsAdapter.NewProviderStore(backend, emitter)
 
 	ctx := withActor(context.Background())
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := backend.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestProviderStore_NoActorNoEvent(t *testing.T) {
 
 	// No user in context (system/seed path): no event should be emitted.
 	ctx := context.Background()
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := backend.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -106,11 +106,11 @@ func TestRoleStore_MemberUpdatedResolvesOrgAndUser(t *testing.T) {
 	store := eventsAdapter.NewRoleStore(backend, emitter, backend)
 
 	ctx := withActor(context.Background())
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := backend.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
-	user := model.NewUser("test", "sub-2", "bob@example.com", "Bob", true, "user")
+	user := model.NewUser(testTenantID, "test", "sub-2", "bob@example.com", "Bob", true, "user")
 	user.SetPreferences(model.NewUserPreferences())
 	if err := backend.SaveUser(ctx, user); err != nil {
 		t.Fatalf("SaveUser: %v", err)
@@ -145,7 +145,7 @@ func TestApplicationStore_TokenEvents(t *testing.T) {
 	store := eventsAdapter.NewApplicationStore(backend, emitter)
 
 	ctx := withActor(context.Background())
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := backend.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -177,3 +177,8 @@ func TestApplicationStore_TokenEvents(t *testing.T) {
 		t.Fatalf("expected label prod, got %q", del.Attributes()["label"])
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/adapter/gorm/database.go
+++ b/internal/adapter/gorm/database.go
@@ -228,6 +228,23 @@ func createGetDatabase(db *gorm.DB) func(ctx context.Context) (*gorm.DB, error) 
 						return errors.WithStack(tx.Migrator().DropTable("application_roles"))
 					},
 				},
+				{
+					// Introduce the tenant level above organizations and users.
+					// Existing instances keep working unchanged: everything is
+					// attached to the "default" tenant, the one Xolo resolves
+					// transparently when multi-tenancy is disabled.
+					ID: "202608130001",
+					Migrate: func(tx *gorm.DB) error {
+						return withoutForeignKeys(tx, func() error {
+							return migrateToDefaultTenant(tx)
+						})
+					},
+					Rollback: func(tx *gorm.DB) error {
+						return withoutForeignKeys(tx, func() error {
+							return rollbackDefaultTenant(tx)
+						})
+					},
+				},
 			})
 
 			m.InitSchema(func(tx *gorm.DB) error {
@@ -240,6 +257,8 @@ func createGetDatabase(db *gorm.DB) func(ctx context.Context) (*gorm.DB, error) 
 					}
 
 					err := tx.AutoMigrate(
+						// Tenant store
+						&Tenant{},
 						// User store
 						&User{}, &AuthToken{}, &UserRole{}, &UserPreferences{},
 						// Org store
@@ -268,6 +287,12 @@ func createGetDatabase(db *gorm.DB) func(ctx context.Context) (*gorm.DB, error) 
 						&Event{}, &Alert{}, &AlertIncident{}, &EventSettings{},
 					)
 					if err != nil {
+						return errors.WithStack(err)
+					}
+
+					// A fresh instance still needs the tenant every organization
+					// and user hangs from, exactly like an upgraded one.
+					if _, err := ensureDefaultTenant(tx); err != nil {
 						return errors.WithStack(err)
 					}
 

--- a/internal/adapter/gorm/migration_rbac_test.go
+++ b/internal/adapter/gorm/migration_rbac_test.go
@@ -32,7 +32,7 @@ func TestMigrateLegacyMembershipRoles(t *testing.T) {
 		t.Fatalf("migrate legacy memberships: %v", err)
 	}
 
-	org := fromOrganization(model.NewOrganization("acme", "Acme", ""))
+	org := fromOrganization(model.NewOrganization(testTenantID, "acme", "Acme", ""))
 	if err := db.Create(org).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
@@ -113,12 +113,12 @@ func TestBackfillApplicationBuiltinRoles(t *testing.T) {
 		t.Fatalf("migrate: %v", err)
 	}
 
-	org := fromOrganization(model.NewOrganization("acme", "Acme", ""))
+	org := fromOrganization(model.NewOrganization(testTenantID, "acme", "Acme", ""))
 	if err := db.Create(org).Error; err != nil {
 		t.Fatalf("create org: %v", err)
 	}
 
-	other := fromOrganization(model.NewOrganization("other", "Other", ""))
+	other := fromOrganization(model.NewOrganization(testTenantID, "other", "Other", ""))
 	if err := db.Create(other).Error; err != nil {
 		t.Fatalf("create other org: %v", err)
 	}
@@ -182,3 +182,8 @@ func TestBackfillApplicationBuiltinRoles(t *testing.T) {
 	// Scoped per org: never assigned another org's member role.
 	assertAssignment("app-3", roleIDByOrg[other.ID])
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/adapter/gorm/migration_tenant.go
+++ b/internal/adapter/gorm/migration_tenant.go
@@ -1,0 +1,120 @@
+package gorm
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"gorm.io/gorm"
+)
+
+// migrateToDefaultTenant introduces the tenant level above organizations and
+// users. Every pre-existing row is attached to a single tenant named after
+// model.DefaultTenantSlug, which is the tenant Xolo transparently uses when
+// multi-tenancy is disabled — the upgrade is invisible to existing instances.
+//
+// It is idempotent: the tenant is only created when missing, and the backfill
+// only touches rows that carry no tenant yet.
+func migrateToDefaultTenant(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&Tenant{}); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// The columns are added before the entities are migrated: AutoMigrate would
+	// otherwise create the composite unique indexes over a column that does not
+	// exist yet.
+	//
+	// They are added nullable rather than through Migrator().AddColumn, which
+	// would emit the NOT NULL of the struct tag: SQLite refuses to add a NOT NULL
+	// column with no default to a populated table. The constraint is applied by
+	// the AutoMigrate at the end of this function, once every row carries a
+	// tenant.
+	for _, table := range []string{"organizations", "users"} {
+		if tx.Migrator().HasTable(table) && !tx.Migrator().HasColumn(table, "tenant_id") {
+			stmt := "ALTER TABLE " + tx.Statement.Quote(table) + " ADD COLUMN tenant_id text"
+			if err := tx.Exec(stmt).Error; err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+
+	tenantID, err := ensureDefaultTenant(tx)
+	if err != nil {
+		return err
+	}
+
+	for _, table := range []string{"organizations", "users"} {
+		stmt := "UPDATE " + tx.Statement.Quote(table) + " SET tenant_id = ? WHERE tenant_id IS NULL OR tenant_id = ''"
+		if err := tx.Exec(stmt, tenantID).Error; err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	// The pre-existing unique indexes are instance-wide; they must go before the
+	// tenant-scoped ones can replace them, otherwise two tenants could never
+	// share an organization slug or an identity.
+	//
+	// They are dropped by their literal name, not by struct field: the field now
+	// carries the composite index, so asking GORM to resolve the name from the
+	// current tag would look up the replacement instead of the index being
+	// removed.
+	for _, idx := range []struct {
+		table string
+		name  string
+	}{
+		{"organizations", "idx_organizations_slug"},
+		{"users", "idx_users_email_nonempty"},
+	} {
+		if !tx.Migrator().HasTable(idx.table) || !tx.Migrator().HasIndex(idx.table, idx.name) {
+			continue
+		}
+		if err := tx.Migrator().DropIndex(idx.table, idx.name); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return errors.WithStack(tx.AutoMigrate(&Organization{}, &User{}))
+}
+
+// ensureDefaultTenant returns the ID of the default tenant, creating it when it
+// does not exist yet.
+func ensureDefaultTenant(tx *gorm.DB) (string, error) {
+	var existing Tenant
+	err := tx.Where("slug = ?", model.DefaultTenantSlug).First(&existing).Error
+	if err == nil {
+		return existing.ID, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", errors.WithStack(err)
+	}
+
+	now := time.Now()
+	tenant := &Tenant{
+		ID:          string(model.NewTenantID()),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Slug:        model.DefaultTenantSlug,
+		Name:        "Default",
+		Description: "Tenant hosting every organization of this instance.",
+		Active:      1,
+	}
+	if err := tx.Create(tenant).Error; err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return tenant.ID, nil
+}
+
+// rollbackDefaultTenant undoes migrateToDefaultTenant.
+func rollbackDefaultTenant(tx *gorm.DB) error {
+	for _, m := range []any{&Organization{}, &User{}} {
+		if !tx.Migrator().HasColumn(m, "tenant_id") {
+			continue
+		}
+		if err := tx.Migrator().DropColumn(m, "tenant_id"); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return errors.WithStack(tx.Migrator().DropTable("tenants"))
+}

--- a/internal/adapter/gorm/migration_tenant_test.go
+++ b/internal/adapter/gorm/migration_tenant_test.go
@@ -1,0 +1,120 @@
+package gorm
+
+import (
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/embed"
+	"github.com/ncruces/go-sqlite3/gormlite"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	gormpkg "gorm.io/gorm"
+)
+
+// legacyOrganization is the organizations table as it stood before tenants:
+// the slug carried an instance-wide unique index and there was no tenant_id.
+type legacyOrganization struct {
+	ID          string `gorm:"primaryKey;autoIncrement:false"`
+	Slug        string `gorm:"uniqueIndex;not null"`
+	Name        string `gorm:"not null"`
+	Description string
+	Active      int
+	Currency    string `gorm:"not null;default:'USD'"`
+}
+
+// legacyUser is the users table before tenants: the identity was unique
+// instance-wide.
+type legacyUser struct {
+	ID          string `gorm:"primaryKey;autoIncrement:false"`
+	Subject     string `gorm:"index"`
+	Provider    string `gorm:"index"`
+	DisplayName string
+	Email       string `gorm:"uniqueIndex:idx_users_email_nonempty,where:email != ''"`
+	Active      bool
+}
+
+// TestMigrateToDefaultTenant exercises the upgrade path of an existing
+// instance: every organization and user must end up attached to the default
+// tenant, without anyone having to touch a configuration file.
+func TestMigrateToDefaultTenant(t *testing.T) {
+	db, err := gormpkg.Open(gormlite.Open(":memory:"), &gormpkg.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	if err := db.Table("organizations").AutoMigrate(&legacyOrganization{}); err != nil {
+		t.Fatalf("migrate legacy organizations: %v", err)
+	}
+	if err := db.Table("users").AutoMigrate(&legacyUser{}); err != nil {
+		t.Fatalf("migrate legacy users: %v", err)
+	}
+
+	orgs := []legacyOrganization{
+		{ID: "org-1", Slug: "acme", Name: "Acme", Active: 1, Currency: "EUR"},
+		{ID: "org-2", Slug: "globex", Name: "Globex", Active: 1, Currency: "USD"},
+	}
+	for _, org := range orgs {
+		if err := db.Table("organizations").Create(&org).Error; err != nil {
+			t.Fatalf("create legacy org %q: %v", org.Slug, err)
+		}
+	}
+
+	users := []legacyUser{
+		{ID: "user-1", Provider: "openid-connect", Subject: "sub-1", Email: "jean@acme.tld", Active: true},
+		{ID: "user-2", Provider: "openid-connect", Subject: "sub-2", Email: "marie@globex.tld", Active: true},
+	}
+	for _, user := range users {
+		if err := db.Table("users").Create(&user).Error; err != nil {
+			t.Fatalf("create legacy user %q: %v", user.Subject, err)
+		}
+	}
+
+	if err := withoutForeignKeys(db, func() error { return migrateToDefaultTenant(db) }); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var tenant Tenant
+	if err := db.First(&tenant, "slug = ?", model.DefaultTenantSlug).Error; err != nil {
+		t.Fatalf("default tenant should exist: %v", err)
+	}
+
+	for _, table := range []string{"organizations", "users"} {
+		var orphans int64
+		err := db.Table(table).Where("tenant_id IS NULL OR tenant_id != ?", tenant.ID).Count(&orphans).Error
+		if err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if orphans != 0 {
+			t.Errorf("%s: %d rows are not attached to the default tenant", table, orphans)
+		}
+	}
+
+	// The instance-wide unique indexes must be gone, otherwise a second tenant
+	// could never reuse a slug or an identity.
+	store := NewStore(db)
+	ctx := t.Context()
+
+	other := model.NewTenant("other", "Other", "")
+	if err := store.CreateTenant(ctx, other); err != nil {
+		t.Fatalf("create second tenant: %v", err)
+	}
+
+	if err := store.CreateOrg(ctx, model.NewOrganization(other.ID(), "acme", "Acme", "")); err != nil {
+		t.Errorf("the slug %q should be reusable in another tenant: %v", "acme", err)
+	}
+	if err := store.SaveUser(ctx, model.NewUser(other.ID(), "openid-connect", "sub-1", "jean@acme.tld", "Jean", true)); err != nil {
+		t.Errorf("the identity should be reusable in another tenant: %v", err)
+	}
+
+	// Re-running the migration must be a no-op: it is replayed on any database
+	// that already went through it.
+	if err := withoutForeignKeys(db, func() error { return migrateToDefaultTenant(db) }); err != nil {
+		t.Fatalf("second migration run: %v", err)
+	}
+
+	var tenants int64
+	if err := db.Model(&Tenant{}).Where("slug = ?", model.DefaultTenantSlug).Count(&tenants).Error; err != nil {
+		t.Fatalf("count tenants: %v", err)
+	}
+	if tenants != 1 {
+		t.Errorf("default tenants: got %d, want 1", tenants)
+	}
+}

--- a/internal/adapter/gorm/org_store.go
+++ b/internal/adapter/gorm/org_store.go
@@ -3,9 +3,9 @@ package gorm
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
-	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -42,10 +42,10 @@ func (s *Store) GetOrgByID(ctx context.Context, id model.OrgID) (model.Organizat
 }
 
 // GetOrgBySlug implements port.OrgStore.
-func (s *Store) GetOrgBySlug(ctx context.Context, slug string) (model.Organization, error) {
+func (s *Store) GetOrgBySlug(ctx context.Context, tenantID model.TenantID, slug string) (model.Organization, error) {
 	var org Organization
 	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
-		if err := db.First(&org, "slug = ?", slug).Error; err != nil {
+		if err := db.First(&org, "tenant_id = ? AND slug = ?", string(tenantID), slug).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return errors.WithStack(port.ErrNotFound)
 			}
@@ -66,6 +66,10 @@ func (s *Store) ListOrgs(ctx context.Context, opts port.ListOrgsOptions) ([]mode
 
 	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
 		query := db.Model(&Organization{})
+
+		if opts.TenantID != nil {
+			query = query.Where("tenant_id = ?", string(*opts.TenantID))
+		}
 
 		if err := query.Count(&total).Error; err != nil {
 			return errors.WithStack(err)
@@ -116,71 +120,79 @@ func (s *Store) DeleteOrg(ctx context.Context, id model.OrgID) error {
 			return errors.WithStack(err)
 		}
 
-		// Subqueries are evaluated when the DELETE they belong to runs, so every
-		// statement using them must be issued before its parent rows are gone.
-		membershipIDs := db.Model(&Membership{}).Select("id").Where("org_id = ?", string(id))
-		roleIDs := db.Model(&Role{}).Select("id").Where("org_id = ?", string(id))
-		applicationIDs := db.Model(&Application{}).Select("id").Where("org_id = ?", string(id))
-		alertIDs := db.Model(&Alert{}).Select("id").Where("org_id = ?", string(id))
-
-		if err := db.Where("membership_id IN (?)", membershipIDs).Delete(&MembershipRole{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-
-		if err := db.Where("role_id IN (?)", roleIDs).Delete(&MembershipRole{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("role_id IN (?)", roleIDs).Delete(&ApplicationRole{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("role_id IN (?)", roleIDs).Delete(&RolePermission{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("role_id IN (?)", roleIDs).Delete(&RoleModel{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-
-		if err := db.Where("application_id IN (?)", applicationIDs).Delete(&ApplicationRole{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("org_id = ? OR application_id IN (?)", string(id), applicationIDs).Delete(&AuthToken{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("scope = ? AND scope_id IN (?)", string(model.QuotaScopeApplication), applicationIDs).Delete(&Quota{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-		if err := db.Where("alert_id IN (?)", alertIDs).Delete(&AlertIncident{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-
-		if err := db.Where("scope = ? AND scope_id = ?", string(model.QuotaScopeOrg), string(id)).Delete(&Quota{}).Error; err != nil {
-			return errors.WithStack(err)
-		}
-
-		orgScoped := []any{
-			&Application{},
-			&Membership{},
-			&InviteToken{},
-			&Role{},
-			&Alert{},
-			&AlertIncident{},
-			&UsageRecord{},
-			&Event{},
-			&EventSettings{},
-			&VirtualModel{},
-			&Middleware{},
-			&PluginNodeSecret{},
-			&Provider{},
-			&LLMModel{},
-		}
-		for _, m := range orgScoped {
-			if err := db.Where("org_id = ?", string(id)).Delete(m).Error; err != nil {
-				return errors.WithStack(err)
-			}
-		}
-
-		return errors.WithStack(db.Delete(&Organization{}, "id = ?", string(id)).Error)
+		return deleteOrgWithin(db, id)
 	})
+}
+
+// deleteOrgWithin holds the actual cascade, without the existence check, so
+// DeleteTenant can replay it for every organization it owns inside its own
+// transaction. The list of org-scoped models below is the de facto definition
+// of the organization footprint: any new org-scoped table must be added here.
+func deleteOrgWithin(db *gorm.DB, id model.OrgID) error {
+	// Subqueries are evaluated when the DELETE they belong to runs, so every
+	// statement using them must be issued before its parent rows are gone.
+	membershipIDs := db.Model(&Membership{}).Select("id").Where("org_id = ?", string(id))
+	roleIDs := db.Model(&Role{}).Select("id").Where("org_id = ?", string(id))
+	applicationIDs := db.Model(&Application{}).Select("id").Where("org_id = ?", string(id))
+	alertIDs := db.Model(&Alert{}).Select("id").Where("org_id = ?", string(id))
+
+	if err := db.Where("membership_id IN (?)", membershipIDs).Delete(&MembershipRole{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := db.Where("role_id IN (?)", roleIDs).Delete(&MembershipRole{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("role_id IN (?)", roleIDs).Delete(&ApplicationRole{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("role_id IN (?)", roleIDs).Delete(&RolePermission{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("role_id IN (?)", roleIDs).Delete(&RoleModel{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := db.Where("application_id IN (?)", applicationIDs).Delete(&ApplicationRole{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("org_id = ? OR application_id IN (?)", string(id), applicationIDs).Delete(&AuthToken{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("scope = ? AND scope_id IN (?)", string(model.QuotaScopeApplication), applicationIDs).Delete(&Quota{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.Where("alert_id IN (?)", alertIDs).Delete(&AlertIncident{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := db.Where("scope = ? AND scope_id = ?", string(model.QuotaScopeOrg), string(id)).Delete(&Quota{}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+
+	orgScoped := []any{
+		&Application{},
+		&Membership{},
+		&InviteToken{},
+		&Role{},
+		&Alert{},
+		&AlertIncident{},
+		&UsageRecord{},
+		&Event{},
+		&EventSettings{},
+		&VirtualModel{},
+		&Middleware{},
+		&PluginNodeSecret{},
+		&Provider{},
+		&LLMModel{},
+	}
+	for _, m := range orgScoped {
+		if err := db.Where("org_id = ?", string(id)).Delete(m).Error; err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return errors.WithStack(db.Delete(&Organization{}, "id = ?", string(id)).Error)
 }
 
 // AddMember implements port.OrgStore.

--- a/internal/adapter/gorm/organization.go
+++ b/internal/adapter/gorm/organization.go
@@ -10,7 +10,8 @@ type Organization struct {
 	ID          string `gorm:"primaryKey;autoIncrement:false"`
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
-	Slug        string `gorm:"uniqueIndex;not null"`
+	TenantID    string `gorm:"index;uniqueIndex:idx_org_tenant_slug;not null"`
+	Slug        string `gorm:"uniqueIndex:idx_org_tenant_slug;not null"`
 	Name        string `gorm:"not null"`
 	Description string
 	// No `default` on the flag columns below: GORM omits a zero-valued field
@@ -30,6 +31,7 @@ type wrappedOrganization struct {
 }
 
 func (w *wrappedOrganization) ID() model.OrgID          { return model.OrgID(w.o.ID) }
+func (w *wrappedOrganization) TenantID() model.TenantID  { return model.TenantID(w.o.TenantID) }
 func (w *wrappedOrganization) Slug() string              { return w.o.Slug }
 func (w *wrappedOrganization) Name() string              { return w.o.Name }
 func (w *wrappedOrganization) Description() string       { return w.o.Description }
@@ -55,6 +57,7 @@ func fromOrganization(org model.Organization) *Organization {
 	}
 	return &Organization{
 		ID:          string(org.ID()),
+		TenantID:    string(org.TenantID()),
 		Slug:        org.Slug(),
 		Name:        org.Name(),
 		Description: org.Description(),

--- a/internal/adapter/gorm/repository_apps_test.go
+++ b/internal/adapter/gorm/repository_apps_test.go
@@ -18,11 +18,11 @@ func TestApplicationStore_Lifecycle(t *testing.T) {
 func scenarioApplicationStoreLifecycle(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
-	otherOrg := model.NewOrganization("other", "Other", "")
+	otherOrg := model.NewOrganization(testTenantID, "other", "Other", "")
 	if err := store.CreateOrg(ctx, otherOrg); err != nil {
 		t.Fatalf("CreateOrg (other): %v", err)
 	}
@@ -81,7 +81,7 @@ func TestApplicationStore_AuthTokens(t *testing.T) {
 func scenarioApplicationStoreAuthTokens(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestInviteStore_Lifecycle(t *testing.T) {
 func scenarioInviteStoreLifecycle(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestInviteStore_ExpiredNotPending(t *testing.T) {
 func scenarioInviteStoreExpiredNotPending(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -256,3 +256,8 @@ func scenarioInviteStoreExpiredNotPending(t *testing.T, store *xologorm.Store) {
 		t.Errorf("expected an expired invite not to be pending, got %d", len(pending))
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/adapter/gorm/repository_models_test.go
+++ b/internal/adapter/gorm/repository_models_test.go
@@ -33,11 +33,11 @@ func TestProviderStore_Providers(t *testing.T) {
 func scenarioProviderStoreProviders(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
-	otherOrg := model.NewOrganization("other", "Other", "")
+	otherOrg := model.NewOrganization(testTenantID, "other", "Other", "")
 	if err := store.CreateOrg(ctx, otherOrg); err != nil {
 		t.Fatalf("CreateOrg (other): %v", err)
 	}
@@ -104,7 +104,7 @@ func TestProviderStore_LLMModels(t *testing.T) {
 func scenarioProviderStoreLLMModels(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestDefaultedFlagsCanBeCleared(t *testing.T) {
 func scenarioDefaultedFlagsCanBeCleared(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestVirtualModelStore_Lifecycle(t *testing.T) {
 func scenarioVirtualModelStoreLifecycle(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestMiddlewareStore_EnabledOrdering(t *testing.T) {
 func scenarioMiddlewareStoreEnabledOrdering(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}

--- a/internal/adapter/gorm/repository_orgs_test.go
+++ b/internal/adapter/gorm/repository_orgs_test.go
@@ -17,7 +17,7 @@ func TestOrgStore_Lifecycle(t *testing.T) {
 func scenarioOrgStoreLifecycle(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme Corp", "The description", "EUR")
+	org := model.NewOrganization(testTenantID, "acme", "Acme Corp", "The description", "EUR")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -30,7 +30,7 @@ func scenarioOrgStoreLifecycle(t *testing.T, store *xologorm.Store) {
 		t.Errorf("unexpected org round-trip: name=%q currency=%q active=%v", byID.Name(), byID.Currency(), byID.Active())
 	}
 
-	bySlug, err := store.GetOrgBySlug(ctx, "acme")
+	bySlug, err := store.GetOrgBySlug(ctx, testTenantID, "acme")
 	if err != nil {
 		t.Fatalf("GetOrgBySlug: %v", err)
 	}
@@ -38,7 +38,7 @@ func scenarioOrgStoreLifecycle(t *testing.T, store *xologorm.Store) {
 		t.Errorf("expected org %q, got %q", org.ID(), bySlug.ID())
 	}
 
-	if _, err := store.GetOrgBySlug(ctx, "unknown"); !errors.Is(err, port.ErrNotFound) {
+	if _, err := store.GetOrgBySlug(ctx, testTenantID, "unknown"); !errors.Is(err, port.ErrNotFound) {
 		t.Fatalf("GetOrgBySlug (unknown): expected port.ErrNotFound, got %v", err)
 	}
 	if _, err := store.GetOrgByID(ctx, model.NewOrgID()); !errors.Is(err, port.ErrNotFound) {
@@ -79,7 +79,7 @@ func TestOrgStore_DeletePurgesScopedData(t *testing.T) {
 func scenarioOrgStoreDeletePurgesScopedData(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme Corp", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme Corp", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -126,7 +126,7 @@ func scenarioOrgStoreListPagination(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
 	for _, slug := range []string{"org-a", "org-b", "org-c"} {
-		if err := store.CreateOrg(ctx, model.NewOrganization(slug, slug, "")); err != nil {
+		if err := store.CreateOrg(ctx, model.NewOrganization(testTenantID, slug, slug, "")); err != nil {
 			t.Fatalf("CreateOrg(%s): %v", slug, err)
 		}
 	}
@@ -158,11 +158,11 @@ func TestOrgStore_Memberships(t *testing.T) {
 func scenarioOrgStoreMemberships(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
-	otherOrg := model.NewOrganization("other", "Other", "")
+	otherOrg := model.NewOrganization(testTenantID, "other", "Other", "")
 	if err := store.CreateOrg(ctx, otherOrg); err != nil {
 		t.Fatalf("CreateOrg (other): %v", err)
 	}

--- a/internal/adapter/gorm/repository_tenants_test.go
+++ b/internal/adapter/gorm/repository_tenants_test.go
@@ -1,0 +1,227 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	xologorm "github.com/xolo-gateway/xolo/internal/adapter/gorm"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+)
+
+func TestTenantCRUD(t *testing.T) {
+	eachBackend(t, func(t *testing.T, store *xologorm.Store) {
+		ctx := context.Background()
+
+		tenant := model.NewTenant("acme", "Acme", "Acme Inc.")
+		if err := store.CreateTenant(ctx, tenant); err != nil {
+			t.Fatalf("create tenant: %v", err)
+		}
+
+		byID, err := store.GetTenantByID(ctx, tenant.ID())
+		if err != nil {
+			t.Fatalf("get tenant by id: %v", err)
+		}
+		if byID.Slug() != "acme" || byID.Name() != "Acme" || !byID.Active() {
+			t.Errorf("tenant: got %q/%q/active=%v", byID.Slug(), byID.Name(), byID.Active())
+		}
+
+		bySlug, err := store.GetTenantBySlug(ctx, "acme")
+		if err != nil {
+			t.Fatalf("get tenant by slug: %v", err)
+		}
+		if bySlug.ID() != tenant.ID() {
+			t.Errorf("id: got %q, want %q", bySlug.ID(), tenant.ID())
+		}
+
+		// A deactivation must survive the round-trip: the Active column is an int
+		// precisely so GORM does not drop the zero value from the statement.
+		updated := model.UpdateTenant(tenant, model.WithTenantActive(false), model.WithTenantName("Acme Corp"))
+		if err := store.SaveTenant(ctx, updated); err != nil {
+			t.Fatalf("save tenant: %v", err)
+		}
+
+		reloaded, err := store.GetTenantByID(ctx, tenant.ID())
+		if err != nil {
+			t.Fatalf("reload tenant: %v", err)
+		}
+		if reloaded.Active() {
+			t.Error("tenant should be inactive")
+		}
+		if reloaded.Name() != "Acme Corp" {
+			t.Errorf("name: got %q, want %q", reloaded.Name(), "Acme Corp")
+		}
+
+		if err := store.CreateTenant(ctx, model.NewTenant("acme", "Acme again", "")); !errors.Is(err, port.ErrAlreadyExists) {
+			t.Errorf("duplicate slug: got %v, want %v", err, port.ErrAlreadyExists)
+		}
+
+		if _, err := store.GetTenantBySlug(ctx, "unknown"); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("unknown slug: got %v, want %v", err, port.ErrNotFound)
+		}
+	})
+}
+
+func TestDefaultTenantExists(t *testing.T) {
+	eachBackend(t, func(t *testing.T, store *xologorm.Store) {
+		// A fresh instance must own the tenant everything hangs from, exactly like
+		// one upgraded from a pre-tenant schema.
+		tenant, err := store.GetTenantBySlug(context.Background(), model.DefaultTenantSlug)
+		if err != nil {
+			t.Fatalf("get default tenant: %v", err)
+		}
+		if !tenant.Active() {
+			t.Error("the default tenant should be active")
+		}
+	})
+}
+
+// TestTenantIsolation is the core guarantee of multi-tenancy: two tenants may
+// hold an organization with the same slug and a user with the same identity,
+// and neither can read the other's.
+func TestTenantIsolation(t *testing.T) {
+	eachBackend(t, func(t *testing.T, store *xologorm.Store) {
+		ctx := context.Background()
+
+		first := model.NewTenant("first", "First", "")
+		second := model.NewTenant("second", "Second", "")
+		for _, tenant := range []model.Tenant{first, second} {
+			if err := store.CreateTenant(ctx, tenant); err != nil {
+				t.Fatalf("create tenant %q: %v", tenant.Slug(), err)
+			}
+		}
+
+		firstOrg := model.NewOrganization(first.ID(), "acme", "Acme", "")
+		secondOrg := model.NewOrganization(second.ID(), "acme", "Acme", "")
+		for _, org := range []model.Organization{firstOrg, secondOrg} {
+			if err := store.CreateOrg(ctx, org); err != nil {
+				t.Fatalf("create org in tenant %q: %v", org.TenantID(), err)
+			}
+		}
+
+		resolved, err := store.GetOrgBySlug(ctx, first.ID(), "acme")
+		if err != nil {
+			t.Fatalf("get org by slug: %v", err)
+		}
+		if resolved.ID() != firstOrg.ID() {
+			t.Errorf("slug %q resolved to the other tenant's organization", "acme")
+		}
+
+		firstUser := model.NewUser(first.ID(), "openid-connect", "sub-1", "jean@first.tld", "Jean", true)
+		secondUser := model.NewUser(second.ID(), "openid-connect", "sub-1", "jean@second.tld", "Jean", true)
+		for _, user := range []model.User{firstUser, secondUser} {
+			if err := store.SaveUser(ctx, user); err != nil {
+				t.Fatalf("save user in tenant %q: %v", user.TenantID(), err)
+			}
+		}
+
+		found, err := store.GetUserByIdentity(ctx, second.ID(), "openid-connect", "sub-1")
+		if err != nil {
+			t.Fatalf("get user by identity: %v", err)
+		}
+		if found.ID() != secondUser.ID() {
+			t.Errorf("identity resolved to the other tenant's user")
+		}
+
+		// The listings must not leak across the boundary either.
+		firstID := first.ID()
+		orgs, _, err := store.ListOrgs(ctx, port.ListOrgsOptions{TenantID: &firstID})
+		if err != nil {
+			t.Fatalf("list orgs: %v", err)
+		}
+		if len(orgs) != 1 || orgs[0].ID() != firstOrg.ID() {
+			t.Errorf("orgs: got %d rows, want only the first tenant's organization", len(orgs))
+		}
+
+		users, err := store.QueryUsers(ctx, port.QueryUsersOptions{TenantID: &firstID})
+		if err != nil {
+			t.Fatalf("query users: %v", err)
+		}
+		if len(users) != 1 || users[0].ID() != firstUser.ID() {
+			t.Errorf("users: got %d rows, want only the first tenant's user", len(users))
+		}
+
+		count, err := store.CountUsers(ctx, port.QueryUsersOptions{TenantID: &firstID})
+		if err != nil {
+			t.Fatalf("count users: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("user count: got %d, want 1", count)
+		}
+	})
+}
+
+// TestDeleteTenant checks the applicative cascade: no foreign key backs the
+// tenant column, so everything it owns is removed explicitly.
+func TestDeleteTenant(t *testing.T) {
+	eachBackend(t, func(t *testing.T, store *xologorm.Store) {
+		ctx := context.Background()
+
+		tenant := model.NewTenant("doomed", "Doomed", "")
+		if err := store.CreateTenant(ctx, tenant); err != nil {
+			t.Fatalf("create tenant: %v", err)
+		}
+
+		org := model.NewOrganization(tenant.ID(), "acme", "Acme", "")
+		if err := store.CreateOrg(ctx, org); err != nil {
+			t.Fatalf("create org: %v", err)
+		}
+		if err := store.EnsureBuiltinRoles(ctx, org.ID()); err != nil {
+			t.Fatalf("ensure builtin roles: %v", err)
+		}
+
+		user := model.NewUser(tenant.ID(), "openid-connect", "sub-1", "jean@doomed.tld", "Jean", true)
+		if err := store.SaveUser(ctx, user); err != nil {
+			t.Fatalf("save user: %v", err)
+		}
+
+		membership := model.NewMembership(user.ID(), org.ID())
+		if err := store.AddMember(ctx, membership); err != nil {
+			t.Fatalf("add member: %v", err)
+		}
+
+		// A neighbouring tenant must come out untouched.
+		other := model.NewTenant("survivor", "Survivor", "")
+		if err := store.CreateTenant(ctx, other); err != nil {
+			t.Fatalf("create other tenant: %v", err)
+		}
+		otherUser := model.NewUser(other.ID(), "openid-connect", "sub-1", "jean@survivor.tld", "Jean", true)
+		if err := store.SaveUser(ctx, otherUser); err != nil {
+			t.Fatalf("save other user: %v", err)
+		}
+
+		if err := store.DeleteTenant(ctx, tenant.ID()); err != nil {
+			t.Fatalf("delete tenant: %v", err)
+		}
+
+		if _, err := store.GetTenantByID(ctx, tenant.ID()); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("tenant: got %v, want %v", err, port.ErrNotFound)
+		}
+		if _, err := store.GetOrgByID(ctx, org.ID()); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("organization: got %v, want %v", err, port.ErrNotFound)
+		}
+		if _, err := store.GetUserByID(ctx, user.ID()); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("user: got %v, want %v", err, port.ErrNotFound)
+		}
+		if _, err := store.GetMembership(ctx, membership.ID()); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("membership: got %v, want %v", err, port.ErrNotFound)
+		}
+
+		roles, err := store.ListOrgRoles(ctx, org.ID())
+		if err != nil {
+			t.Fatalf("list org roles: %v", err)
+		}
+		if len(roles) != 0 {
+			t.Errorf("roles: got %d, want none", len(roles))
+		}
+
+		if _, err := store.GetUserByID(ctx, otherUser.ID()); err != nil {
+			t.Errorf("the other tenant's user should have survived, got %v", err)
+		}
+
+		if err := store.DeleteTenant(ctx, model.TenantID("nope")); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("unknown tenant: got %v, want %v", err, port.ErrNotFound)
+		}
+	})
+}

--- a/internal/adapter/gorm/repository_users_test.go
+++ b/internal/adapter/gorm/repository_users_test.go
@@ -14,7 +14,7 @@ import (
 // newUser builds a user ready to be persisted. NewUser leaves Preferences nil,
 // which the GORM mapping dereferences, so every caller has to seed them.
 func newUser(subject, email, displayName string, active bool, roles ...string) *model.BaseUser {
-	u := model.NewUser("test", subject, email, displayName, active, roles...)
+	u := model.NewUser(testTenantID, "test", subject, email, displayName, active, roles...)
 	u.SetPreferences(model.NewUserPreferences())
 	return u
 }
@@ -27,11 +27,11 @@ func scenarioUserStoreLifecycle(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
 	// FindOrCreateUser is keyed on (provider, subject) and must not duplicate.
-	created, err := store.FindOrCreateUser(ctx, "oidc", "subject-1")
+	created, err := store.FindOrCreateUser(ctx, testTenantID, "oidc", "subject-1")
 	if err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
 	}
-	again, err := store.FindOrCreateUser(ctx, "oidc", "subject-1")
+	again, err := store.FindOrCreateUser(ctx, testTenantID, "oidc", "subject-1")
 	if err != nil {
 		t.Fatalf("FindOrCreateUser (again): %v", err)
 	}
@@ -39,7 +39,7 @@ func scenarioUserStoreLifecycle(t *testing.T, store *xologorm.Store) {
 		t.Fatalf("expected the same user, got %q then %q", created.ID(), again.ID())
 	}
 
-	other, err := store.FindOrCreateUser(ctx, "oidc", "subject-2")
+	other, err := store.FindOrCreateUser(ctx, testTenantID, "oidc", "subject-2")
 	if err != nil {
 		t.Fatalf("FindOrCreateUser (other subject): %v", err)
 	}
@@ -193,7 +193,7 @@ func scenarioUserStoreAuthTokens(t *testing.T, store *xologorm.Store) {
 		t.Fatalf("SaveUser: %v", err)
 	}
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}

--- a/internal/adapter/gorm/role_store_test.go
+++ b/internal/adapter/gorm/role_store_test.go
@@ -16,7 +16,7 @@ func TestRoleStore_BuiltinRolesAndResolution(t *testing.T) {
 func scenarioRoleStore_BuiltinRolesAndResolution(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -50,7 +50,7 @@ func scenarioRoleStore_BuiltinRolesAndResolution(t *testing.T, store *xologorm.S
 	}
 
 	// Member with a member role: usage permission but no admin permission.
-	user := model.NewUser("test", "u1", "u1@example.com", "U1", true, "user")
+	user := model.NewUser(testTenantID, "test", "u1", "u1@example.com", "U1", true, "user")
 	user.SetPreferences(model.NewUserPreferences())
 	if err := store.SaveUser(ctx, user); err != nil {
 		t.Fatalf("SaveUser: %v", err)
@@ -98,7 +98,7 @@ func TestRoleStore_CustomRoleAndModelGrant(t *testing.T) {
 func scenarioRoleStore_CustomRoleAndModelGrant(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestRoleStore_ApplicationRoleResolution(t *testing.T) {
 func scenarioRoleStore_ApplicationRoleResolution(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -209,7 +209,7 @@ func scenarioRoleStore_ApplicationRoleResolution(t *testing.T, store *xologorm.S
 	}
 
 	// A token scoped to another org must not resolve to the app's permissions.
-	other := model.NewOrganization("other", "Other", "")
+	other := model.NewOrganization(testTenantID, "other", "Other", "")
 	if err := store.CreateOrg(ctx, other); err != nil {
 		t.Fatalf("CreateOrg other: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestRoleStore_DeleteRoleClearsApplicationAssignment(t *testing.T) {
 func scenarioRoleStore_DeleteRoleClearsApplicationAssignment(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestRoleStore_BuiltinRoleNotDeletable(t *testing.T) {
 func scenarioRoleStore_BuiltinRoleNotDeletable(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	org := model.NewOrganization("acme", "Acme", "")
+	org := model.NewOrganization(testTenantID, "acme", "Acme", "")
 	if err := store.CreateOrg(ctx, org); err != nil {
 		t.Fatalf("CreateOrg: %v", err)
 	}

--- a/internal/adapter/gorm/tenant.go
+++ b/internal/adapter/gorm/tenant.go
@@ -1,0 +1,44 @@
+package gorm
+
+import (
+	"time"
+
+	"github.com/xolo-gateway/xolo/internal/core/model"
+)
+
+type Tenant struct {
+	ID          string `gorm:"primaryKey;autoIncrement:false"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Slug        string `gorm:"uniqueIndex;not null"`
+	Name        string `gorm:"not null"`
+	Description string
+	// Active is an int for the same reason as Organization.Active: GORM omits a
+	// zero-valued field carrying a DB default from the INSERT, which would make
+	// it impossible to ever persist a deactivation.
+	Active int
+}
+
+type wrappedTenant struct {
+	t *Tenant
+}
+
+func (w *wrappedTenant) ID() model.TenantID   { return model.TenantID(w.t.ID) }
+func (w *wrappedTenant) Slug() string         { return w.t.Slug }
+func (w *wrappedTenant) Name() string         { return w.t.Name }
+func (w *wrappedTenant) Description() string  { return w.t.Description }
+func (w *wrappedTenant) Active() bool         { return w.t.Active != 0 }
+func (w *wrappedTenant) CreatedAt() time.Time { return w.t.CreatedAt }
+func (w *wrappedTenant) UpdatedAt() time.Time { return w.t.UpdatedAt }
+
+var _ model.Tenant = &wrappedTenant{}
+
+func fromTenant(tenant model.Tenant) *Tenant {
+	return &Tenant{
+		ID:          string(tenant.ID()),
+		Slug:        tenant.Slug(),
+		Name:        tenant.Name(),
+		Description: tenant.Description(),
+		Active:      boolToInt(tenant.Active()),
+	}
+}

--- a/internal/adapter/gorm/tenant_store.go
+++ b/internal/adapter/gorm/tenant_store.go
@@ -1,0 +1,161 @@
+package gorm
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// CreateTenant implements port.TenantStore.
+func (s *Store) CreateTenant(ctx context.Context, tenant model.Tenant) error {
+	return s.withRetry(ctx, true, func(ctx context.Context, db *gorm.DB) error {
+		if err := db.Create(fromTenant(tenant)).Error; err != nil {
+			if isUniqueViolation(err, "tenants", "slug") {
+				return errors.Wrapf(port.ErrAlreadyExists, "slug %q is already used by another tenant", tenant.Slug())
+			}
+			return errors.WithStack(err)
+		}
+		return nil
+	})
+}
+
+// GetTenantByID implements port.TenantStore.
+func (s *Store) GetTenantByID(ctx context.Context, id model.TenantID) (model.Tenant, error) {
+	var tenant Tenant
+	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
+		if err := db.First(&tenant, "id = ?", string(id)).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.WithStack(port.ErrNotFound)
+			}
+			return errors.WithStack(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedTenant{&tenant}, nil
+}
+
+// GetTenantBySlug implements port.TenantStore.
+func (s *Store) GetTenantBySlug(ctx context.Context, slug string) (model.Tenant, error) {
+	var tenant Tenant
+	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
+		if err := db.First(&tenant, "slug = ?", slug).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.WithStack(port.ErrNotFound)
+			}
+			return errors.WithStack(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedTenant{&tenant}, nil
+}
+
+// ListTenants implements port.TenantStore.
+func (s *Store) ListTenants(ctx context.Context, opts port.ListTenantsOptions) ([]model.Tenant, int64, error) {
+	var tenants []*Tenant
+	var total int64
+
+	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
+		query := db.Model(&Tenant{})
+
+		if err := query.Count(&total).Error; err != nil {
+			return errors.WithStack(err)
+		}
+
+		if opts.Limit != nil {
+			query = query.Limit(*opts.Limit)
+		}
+		if opts.Page != nil && opts.Limit != nil {
+			query = query.Offset(*opts.Page * *opts.Limit)
+		}
+
+		return errors.WithStack(query.Order("name ASC").Find(&tenants).Error)
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	result := make([]model.Tenant, 0, len(tenants))
+	for _, t := range tenants {
+		result = append(result, &wrappedTenant{t})
+	}
+	return result, total, nil
+}
+
+// SaveTenant implements port.TenantStore.
+func (s *Store) SaveTenant(ctx context.Context, tenant model.Tenant) error {
+	return s.withRetry(ctx, true, func(ctx context.Context, db *gorm.DB) error {
+		return errors.WithStack(db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "id"}},
+			UpdateAll: true,
+		}).Create(fromTenant(tenant)).Error)
+	})
+}
+
+// DeleteTenant implements port.TenantStore. It replays the organization cascade
+// for every organization the tenant owns, then removes the tenant users and the
+// rows keyed on them: users are tenant-scoped, so nothing outside this tenant
+// can reference them.
+func (s *Store) DeleteTenant(ctx context.Context, id model.TenantID) error {
+	return s.withRetry(ctx, true, func(ctx context.Context, db *gorm.DB) error {
+		var exists Tenant
+		if err := db.Select("id").First(&exists, "id = ?", string(id)).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.WithStack(port.ErrNotFound)
+			}
+			return errors.WithStack(err)
+		}
+
+		var orgIDs []string
+		if err := db.Model(&Organization{}).Where("tenant_id = ?", string(id)).Pluck("id", &orgIDs).Error; err != nil {
+			return errors.WithStack(err)
+		}
+		for _, orgID := range orgIDs {
+			if err := deleteOrgWithin(db, model.OrgID(orgID)); err != nil {
+				return err
+			}
+		}
+
+		// Materialized rather than kept as a subquery: the users are deleted
+		// below, which would empty the subquery before the statements that
+		// depend on it have run.
+		var userIDs []string
+		if err := db.Model(&User{}).Where("tenant_id = ?", string(id)).Pluck("id", &userIDs).Error; err != nil {
+			return errors.WithStack(err)
+		}
+
+		if len(userIDs) > 0 {
+			userScoped := []any{
+				&UserRole{},
+				&UserPreferences{},
+				&PersonalVirtualModel{},
+			}
+			for _, m := range userScoped {
+				if err := db.Where("user_id IN ?", userIDs).Delete(m).Error; err != nil {
+					return errors.WithStack(err)
+				}
+			}
+
+			if err := db.Where("owner_id IN ?", userIDs).Delete(&AuthToken{}).Error; err != nil {
+				return errors.WithStack(err)
+			}
+			if err := db.Where("scope = ? AND scope_id IN ?", string(model.QuotaScopeUser), userIDs).Delete(&Quota{}).Error; err != nil {
+				return errors.WithStack(err)
+			}
+			if err := db.Where("id IN ?", userIDs).Delete(&User{}).Error; err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
+		return errors.WithStack(db.Delete(&Tenant{}, "id = ?", string(id)).Error)
+	})
+}

--- a/internal/adapter/gorm/user.go
+++ b/internal/adapter/gorm/user.go
@@ -13,11 +13,15 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	Subject  string `gorm:"index"`
-	Provider string `gorm:"index"`
+	// TenantID scopes the identity: (tenant_id, provider, subject) is the unique
+	// key, so the same person signing in on two tenants owns two accounts.
+	TenantID string `gorm:"index;uniqueIndex:idx_users_tenant_identity,priority:1;uniqueIndex:idx_users_tenant_email_nonempty,priority:1;not null"`
+
+	Subject  string `gorm:"index;uniqueIndex:idx_users_tenant_identity,priority:2"`
+	Provider string `gorm:"index;uniqueIndex:idx_users_tenant_identity,priority:3"`
 
 	DisplayName string
-	Email       string `gorm:"uniqueIndex:idx_users_email_nonempty,where:email != ''"`
+	Email       string `gorm:"uniqueIndex:idx_users_tenant_email_nonempty,priority:2,where:email != ''"`
 
 	AuthTokens []*AuthToken `gorm:"foreignKey:OwnerID;constraint:OnDelete:CASCADE;"`
 
@@ -53,6 +57,7 @@ type UserPreferences struct {
 func fromUser(u model.User) *User {
 	user := &User{
 		ID:          string(u.ID()),
+		TenantID:    string(u.TenantID()),
 		Subject:     u.Subject(),
 		Provider:    u.Provider(),
 		DisplayName: u.DisplayName(),
@@ -150,6 +155,11 @@ func (w *wrappedUser) Active() bool {
 }
 
 // ID implements model.User.
+// TenantID implements model.User.
+func (w *wrappedUser) TenantID() model.TenantID {
+	return model.TenantID(w.u.TenantID)
+}
+
 func (w *wrappedUser) ID() model.UserID {
 	return model.UserID(w.u.ID)
 }

--- a/internal/adapter/gorm/user_store.go
+++ b/internal/adapter/gorm/user_store.go
@@ -31,16 +31,17 @@ func fromAuthToken(t model.AuthToken) *AuthToken {
 }
 
 // FindOrCreateUser implements port.UserStore.
-func (s *Store) FindOrCreateUser(ctx context.Context, provider, subject string) (model.User, error) {
+func (s *Store) FindOrCreateUser(ctx context.Context, tenantID model.TenantID, provider, subject string) (model.User, error) {
 	var user model.User
 	err := s.withRetry(ctx, true, func(ctx context.Context, db *gorm.DB) error {
 		var u User
 
-		err := db.Where("provider = ? AND subject = ?", provider, subject).
+		err := db.Where("tenant_id = ? AND provider = ? AND subject = ?", string(tenantID), provider, subject).
 			Preload("Roles").
 			Preload("Preferences").
 			Attrs(&User{
 				ID:       string(model.NewUserID()),
+				TenantID: string(tenantID),
 				Provider: provider,
 				Subject:  subject,
 				Active:   true,
@@ -81,12 +82,12 @@ func (s *Store) GetUserByID(ctx context.Context, userID model.UserID) (model.Use
 }
 
 // GetUserByIdentity implements port.UserStore.
-func (s *Store) GetUserByIdentity(ctx context.Context, provider, subject string) (model.User, error) {
+func (s *Store) GetUserByIdentity(ctx context.Context, tenantID model.TenantID, provider, subject string) (model.User, error) {
 	var user User
 
 	err := s.withRetry(ctx, false, func(ctx context.Context, db *gorm.DB) error {
 		err := db.Preload("Roles").Preload("Preferences").
-			Where("provider = ? AND subject = ?", provider, subject).
+			Where("tenant_id = ? AND provider = ? AND subject = ?", string(tenantID), provider, subject).
 			First(&user).Error
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -287,6 +288,15 @@ func applyUserSearch(query *gorm.DB, term string) *gorm.DB {
 	)
 }
 
+// applyUserTenant restricts a user query to a single tenant. The column is
+// qualified because the role filter joins user_roles.
+func applyUserTenant(query *gorm.DB, tenantID *model.TenantID) *gorm.DB {
+	if tenantID == nil {
+		return query
+	}
+	return query.Where("users.tenant_id = ?", string(*tenantID))
+}
+
 // CountUsers implements port.UserStore.
 func (s *Store) CountUsers(ctx context.Context, opts port.QueryUsersOptions) (int64, error) {
 	var count int64
@@ -304,6 +314,7 @@ func (s *Store) CountUsers(ctx context.Context, opts port.QueryUsersOptions) (in
 			query = query.Where("active = ?", *opts.Active)
 		}
 
+		query = applyUserTenant(query, opts.TenantID)
 		query = applyUserSearch(query, opts.Search)
 
 		return errors.WithStack(query.Count(&count).Error)
@@ -335,6 +346,7 @@ func (s *Store) QueryUsers(ctx context.Context, opts port.QueryUsersOptions) ([]
 			query = query.Where("active = ?", *opts.Active)
 		}
 
+		query = applyUserTenant(query, opts.TenantID)
 		query = applyUserSearch(query, opts.Search)
 
 		// Apply pagination

--- a/internal/adapter/gorm/user_store_test.go
+++ b/internal/adapter/gorm/user_store_test.go
@@ -22,13 +22,13 @@ func TestUserStore_DuplicateEmailRejected(t *testing.T) {
 func scenarioUserStore_DuplicateEmailRejected(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
-	first := model.NewUser("test", "subject-1", "duplicate@example.com", "First", true)
+	first := model.NewUser(testTenantID, "test", "subject-1", "duplicate@example.com", "First", true)
 	first.SetPreferences(model.NewUserPreferences())
 	if err := store.SaveUser(ctx, first); err != nil {
 		t.Fatalf("SaveUser (first): %v", err)
 	}
 
-	second := model.NewUser("test", "subject-2", "duplicate@example.com", "Second", true)
+	second := model.NewUser(testTenantID, "test", "subject-2", "duplicate@example.com", "Second", true)
 	second.SetPreferences(model.NewUserPreferences())
 	err := store.SaveUser(ctx, second)
 	if !errors.Is(err, port.ErrAlreadyExists) {
@@ -46,7 +46,7 @@ func scenarioUserStore_EmptyEmailsAllowed(t *testing.T, store *xologorm.Store) {
 	ctx := context.Background()
 
 	for _, subject := range []string{"subject-1", "subject-2"} {
-		user := model.NewUser("test", subject, "", "No mail", true)
+		user := model.NewUser(testTenantID, "test", subject, "", "No mail", true)
 		user.SetPreferences(model.NewUserPreferences())
 		if err := store.SaveUser(ctx, user); err != nil {
 			t.Fatalf("SaveUser (%s): %v", subject, err)

--- a/internal/adapter/proxy/org_model_router.go
+++ b/internal/adapter/proxy/org_model_router.go
@@ -78,7 +78,7 @@ func (r *OrgModelRouter) ResolveModel(ctx context.Context, req *genaiProxy.Proxy
 		return nil, "", errors.Errorf("invalid model name %q: expected format \"<org-slug>/<model-name>\"", req.Model)
 	}
 
-	org, err := r.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := r.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			return nil, "", errors.Errorf("model '%s' not available in your organization", req.Model)
@@ -247,7 +247,7 @@ func (r *OrgModelRouter) ResolveRealModel(ctx context.Context, orgID model.OrgID
 	if idx := strings.IndexByte(proxyName, '/'); idx > 0 {
 		orgSlug := proxyName[:idx]
 		proxyName = proxyName[idx+1:]
-		if org, err := r.orgStore.GetOrgBySlug(ctx, orgSlug); err == nil {
+		if org, err := r.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug); err == nil {
 			// When the referenced org differs from the token's org, verify that the
 			// requesting user is actually a member of that org.
 			if org.ID() != orgID {

--- a/internal/adapter/proxy/plugin_hook_adapter.go
+++ b/internal/adapter/proxy/plugin_hook_adapter.go
@@ -203,7 +203,7 @@ func (a *PipelineHookAdapter) applyMiddlewares(ctx context.Context, req *genaiPr
 		return false, nil
 	}
 
-	org, err := a.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := a.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		return false, nil //nolint:nilerr
 	}
@@ -497,7 +497,7 @@ func (a *PipelineHookAdapter) lookupVirtualModel(ctx context.Context, modelName 
 	}
 
 	// Org virtual model
-	org, err := a.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := a.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		return nil, nil, nil //nolint:nilerr
 	}

--- a/internal/adapter/proxy/usage_tracker_test.go
+++ b/internal/adapter/proxy/usage_tracker_test.go
@@ -74,7 +74,7 @@ func TestUsageTrackerUsesProviderCostWhenAvailable(t *testing.T) {
 	providerID := model.NewProviderID()
 	provider := model.NewProvider(orgID, "openrouter", "openrouter", "https://openrouter.ai", "key", "USD")
 	llmModel := model.NewLLMModel(providerID, orgID, "cadoles/test-model", "real/model", "desc", 1000, 2000)
-	org := model.NewOrganization("org-1", "Org 1", "", "USD")
+	org := model.NewOrganization(testTenantID, "org-1", "Org 1", "", "USD")
 
 	tracker, usageStore := newTestTracker(&fakeProviderStore{provider: provider, llmModel: llmModel}, &fakeOrgStore{org: org})
 
@@ -108,7 +108,7 @@ func TestUsageTrackerFallsBackToComputedCost(t *testing.T) {
 	provider := model.NewProvider(orgID, "openai", "openai", "https://api.openai.com", "key", "USD")
 	// 1000 microcents/1K prompt tokens, 2000 microcents/1K completion tokens
 	llmModel := model.NewLLMModel(providerID, orgID, "cadoles/test-model", "real/model", "desc", 1000, 2000)
-	org := model.NewOrganization("org-1", "Org 1", "", "USD")
+	org := model.NewOrganization(testTenantID, "org-1", "Org 1", "", "USD")
 
 	tracker, usageStore := newTestTracker(&fakeProviderStore{provider: provider, llmModel: llmModel}, &fakeOrgStore{org: org})
 
@@ -134,3 +134,8 @@ func TestUsageTrackerFallsBackToComputedCost(t *testing.T) {
 		t.Errorf("CostSource() = %q, want %q", got, want)
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Plugins          PluginsConfig      `envPrefix:"PLUGINS_"`
 	Events           EventsConfig       `envPrefix:"EVENTS_"`
 	ProvisionningAPI ProvisionningAPI   `envPrefix:"PROVISIONNING_API_"`
+	Multitenancy     Multitenancy       `envPrefix:"MULTITENANCY_"`
 	// SecretKey is a 32-byte hex string used for AES-GCM encryption of provider API keys.
 	SecretKey string `env:"SECRET_KEY"`
 }
@@ -89,6 +90,10 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.ProvisionningAPI.Validate(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := c.Multitenancy.Validate(); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/internal/config/multitenancy.go
+++ b/internal/config/multitenancy.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+)
+
+// TenantHostPlaceholder is the marker replaced by the tenant slug in
+// HostPattern.
+const TenantHostPlaceholder = "{tenant}"
+
+// Multitenancy configures the tenant level. It is disabled by default: a
+// standard instance owns a single tenant, created by the schema migration and
+// never surfaced to its users — no subdomain, no UI, no change of URL.
+//
+// Once enabled, the tenant is identified by the request host, and a host that
+// resolves to no tenant is a 404.
+type Multitenancy struct {
+	Enabled bool `env:"ENABLED" envDefault:"false"`
+
+	// HostPattern is the hostname template identifying a tenant, for instance
+	// "{tenant}.xolo.example.com". It may carry a port, which is ignored when
+	// matching.
+	HostPattern string `env:"HOST_PATTERN,expand"`
+
+	// DefaultTenantSlug names the tenant served when multi-tenancy is disabled.
+	DefaultTenantSlug string `env:"DEFAULT_TENANT_SLUG" envDefault:"default"`
+}
+
+// Validate refuses a configuration that enables multi-tenancy without a usable
+// host pattern: without it no request could ever resolve a tenant, so every
+// route would answer 404. An incomplete configuration is a startup failure,
+// never a degraded mode.
+func (c *Multitenancy) Validate() error {
+	if slug := strings.TrimSpace(c.DefaultTenantSlug); slug == "" {
+		return errors.New("XOLO_MULTITENANCY_DEFAULT_TENANT_SLUG can not be empty")
+	} else if !model.IsValidSlug(slug) {
+		return errors.Errorf("XOLO_MULTITENANCY_DEFAULT_TENANT_SLUG %q is not a valid slug", slug)
+	}
+
+	if !c.Enabled {
+		return nil
+	}
+
+	pattern := strings.TrimSpace(c.HostPattern)
+	if pattern == "" {
+		return errors.New("XOLO_MULTITENANCY_HOST_PATTERN is required but not set when XOLO_MULTITENANCY_ENABLED is true")
+	}
+
+	if !strings.Contains(pattern, TenantHostPlaceholder) {
+		return errors.Errorf("XOLO_MULTITENANCY_HOST_PATTERN must contain the %s placeholder (for instance %s.xolo.example.com)", TenantHostPlaceholder, TenantHostPlaceholder)
+	}
+
+	if strings.Count(pattern, TenantHostPlaceholder) > 1 {
+		return errors.Errorf("XOLO_MULTITENANCY_HOST_PATTERN must contain the %s placeholder exactly once", TenantHostPlaceholder)
+	}
+
+	return nil
+}

--- a/internal/config/multitenancy_test.go
+++ b/internal/config/multitenancy_test.go
@@ -1,0 +1,60 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xolo-gateway/xolo/internal/config"
+)
+
+func TestMultitenancyValidate(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		conf    config.Multitenancy
+		wantErr string
+	}{
+		"disabled needs no host pattern": {
+			conf: config.Multitenancy{Enabled: false, DefaultTenantSlug: "default"},
+		},
+		"enabled with a valid pattern": {
+			conf: config.Multitenancy{Enabled: true, HostPattern: "{tenant}.xolo.example.com", DefaultTenantSlug: "default"},
+		},
+		"enabled without a host pattern": {
+			conf:    config.Multitenancy{Enabled: true, DefaultTenantSlug: "default"},
+			wantErr: "XOLO_MULTITENANCY_HOST_PATTERN is required",
+		},
+		"enabled without the placeholder": {
+			conf:    config.Multitenancy{Enabled: true, HostPattern: "xolo.example.com", DefaultTenantSlug: "default"},
+			wantErr: "must contain the {tenant} placeholder",
+		},
+		"placeholder repeated": {
+			conf:    config.Multitenancy{Enabled: true, HostPattern: "{tenant}.{tenant}.example.com", DefaultTenantSlug: "default"},
+			wantErr: "exactly once",
+		},
+		"empty default slug": {
+			conf:    config.Multitenancy{DefaultTenantSlug: "  "},
+			wantErr: "can not be empty",
+		},
+		"malformed default slug": {
+			conf:    config.Multitenancy{DefaultTenantSlug: "Not A Slug"},
+			wantErr: "is not a valid slug",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := testCase.conf.Validate()
+
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("error: got nil, want one containing %q", testCase.wantErr)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Errorf("error: got %q, want one containing %q", err, testCase.wantErr)
+			}
+		})
+	}
+}

--- a/internal/core/model/organization.go
+++ b/internal/core/model/organization.go
@@ -15,6 +15,9 @@ func NewOrgID() OrgID {
 type Organization interface {
 	WithID[OrgID]
 
+	// TenantID is the owning tenant. Slugs are unique per tenant, never
+	// instance-wide.
+	TenantID() TenantID
 	Slug() string
 	Name() string
 	Description() string
@@ -27,6 +30,7 @@ type Organization interface {
 
 type BaseOrganization struct {
 	id                  OrgID
+	tenantID            TenantID
 	slug                string
 	name                string
 	description         string
@@ -38,6 +42,7 @@ type BaseOrganization struct {
 }
 
 func (o *BaseOrganization) ID() OrgID           { return o.id }
+func (o *BaseOrganization) TenantID() TenantID   { return o.tenantID }
 func (o *BaseOrganization) Slug() string         { return o.slug }
 func (o *BaseOrganization) Name() string         { return o.name }
 func (o *BaseOrganization) Description() string  { return o.description }
@@ -49,13 +54,14 @@ func (o *BaseOrganization) ShareQuotaEqually() bool { return o.shareQuotaEqually
 
 var _ Organization = &BaseOrganization{}
 
-func NewOrganization(slug, name, description string, currency ...string) *BaseOrganization {
+func NewOrganization(tenantID TenantID, slug, name, description string, currency ...string) *BaseOrganization {
 	cur := DefaultCurrency
 	if len(currency) > 0 && currency[0] != "" {
 		cur = currency[0]
 	}
 	return &BaseOrganization{
 		id:          NewOrgID(),
+		tenantID:    tenantID,
 		slug:        slug,
 		name:        name,
 		description: description,
@@ -77,6 +83,7 @@ func WithOrgShareQuotaEqually(v bool) OrgOption { return func(o *BaseOrganizatio
 func UpdateOrganization(org Organization, opts ...OrgOption) *BaseOrganization {
 	b := &BaseOrganization{
 		id:                  org.ID(),
+		tenantID:            org.TenantID(),
 		slug:                org.Slug(),
 		name:                org.Name(),
 		description:         org.Description(),

--- a/internal/core/model/slug.go
+++ b/internal/core/model/slug.go
@@ -1,0 +1,19 @@
+package model
+
+import "regexp"
+
+// SlugPattern matches a DNS-label-like identifier, the form external systems
+// (Kubernetes operators, Terraform providers) can always produce. It lives here
+// rather than in the provisioning service because the same shape is required in
+// three unrelated places: organization slugs, tenant slugs, and the tenant
+// segment extracted from a request host in multi-tenant mode — a subdomain
+// label is exactly a DNS label.
+var SlugPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// MaxSlugLength is the maximum length of a slug, aligned on the DNS label limit.
+const MaxSlugLength = 63
+
+// IsValidSlug reports whether s is a well-formed slug.
+func IsValidSlug(s string) bool {
+	return s != "" && len(s) <= MaxSlugLength && SlugPattern.MatchString(s)
+}

--- a/internal/core/model/tenant.go
+++ b/internal/core/model/tenant.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"time"
+
+	"github.com/rs/xid"
+)
+
+type TenantID string
+
+func NewTenantID() TenantID {
+	return TenantID(xid.New().String())
+}
+
+// DefaultTenantSlug is the slug of the tenant every Xolo instance owns. It is
+// created by the schema migration, owns every pre-existing organization and
+// user, and is the tenant transparently used when multi-tenancy is disabled.
+const DefaultTenantSlug = "default"
+
+// Tenant is the outermost isolation boundary: it owns organizations and users.
+// In single-tenant mode — the default — a single tenant named after
+// DefaultTenantSlug exists and is never surfaced to the user.
+type Tenant interface {
+	WithID[TenantID]
+
+	Slug() string
+	Name() string
+	Description() string
+	Active() bool
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+}
+
+type BaseTenant struct {
+	id          TenantID
+	slug        string
+	name        string
+	description string
+	active      bool
+	createdAt   time.Time
+	updatedAt   time.Time
+}
+
+func (t *BaseTenant) ID() TenantID         { return t.id }
+func (t *BaseTenant) Slug() string         { return t.slug }
+func (t *BaseTenant) Name() string         { return t.name }
+func (t *BaseTenant) Description() string  { return t.description }
+func (t *BaseTenant) Active() bool         { return t.active }
+func (t *BaseTenant) CreatedAt() time.Time { return t.createdAt }
+func (t *BaseTenant) UpdatedAt() time.Time { return t.updatedAt }
+
+var _ Tenant = &BaseTenant{}
+
+func NewTenant(slug, name, description string) *BaseTenant {
+	now := time.Now()
+	return &BaseTenant{
+		id:          NewTenantID(),
+		slug:        slug,
+		name:        name,
+		description: description,
+		active:      true,
+		createdAt:   now,
+		updatedAt:   now,
+	}
+}
+
+type TenantOption func(*BaseTenant)
+
+func WithTenantName(name string) TenantOption { return func(t *BaseTenant) { t.name = name } }
+func WithTenantDescription(desc string) TenantOption {
+	return func(t *BaseTenant) { t.description = desc }
+}
+func WithTenantActive(active bool) TenantOption { return func(t *BaseTenant) { t.active = active } }
+
+// UpdateTenant copies the tenant and applies the options. The slug is
+// deliberately absent: it is the stable handle external systems reconcile on,
+// and in multi-tenant mode it is also part of the hostname.
+func UpdateTenant(tenant Tenant, opts ...TenantOption) *BaseTenant {
+	b := &BaseTenant{
+		id:          tenant.ID(),
+		slug:        tenant.Slug(),
+		name:        tenant.Name(),
+		description: tenant.Description(),
+		active:      tenant.Active(),
+		createdAt:   tenant.CreatedAt(),
+		updatedAt:   time.Now(),
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}

--- a/internal/core/model/user.go
+++ b/internal/core/model/user.go
@@ -23,6 +23,11 @@ func NewUserID() UserID {
 type User interface {
 	WithID[UserID]
 
+	// TenantID is the owning tenant. The identity tuple (provider, subject) is
+	// unique per tenant, not instance-wide: the same person authenticating on
+	// two tenants owns two distinct accounts.
+	TenantID() TenantID
+
 	Email() string
 
 	Subject() string
@@ -39,6 +44,7 @@ type User interface {
 
 type BaseUser struct {
 	id          UserID
+	tenantID    TenantID
 	displayName string
 	email       string
 	subject     string
@@ -68,6 +74,11 @@ func (u *BaseUser) ID() UserID {
 	return u.id
 }
 
+// TenantID implements [User].
+func (u *BaseUser) TenantID() TenantID {
+	return u.tenantID
+}
+
 // DisplayName implements User.
 func (u *BaseUser) DisplayName() string {
 	return u.displayName
@@ -93,6 +104,7 @@ var _ User = &BaseUser{}
 func CopyUser(user User) *BaseUser {
 	return &BaseUser{
 		id:          user.ID(),
+		tenantID:    user.TenantID(),
 		displayName: user.DisplayName(),
 		email:       user.Email(),
 		subject:     user.Subject(),
@@ -103,9 +115,10 @@ func CopyUser(user User) *BaseUser {
 	}
 }
 
-func NewUser(provider, subject, email string, displayName string, active bool, roles ...string) *BaseUser {
+func NewUser(tenantID TenantID, provider, subject, email string, displayName string, active bool, roles ...string) *BaseUser {
 	return &BaseUser{
 		id:          NewUserID(),
+		tenantID:    tenantID,
 		displayName: displayName,
 		email:       email,
 		subject:     subject,

--- a/internal/core/port/org_store.go
+++ b/internal/core/port/org_store.go
@@ -10,7 +10,9 @@ type OrgStore interface {
 	// Organizations
 	CreateOrg(ctx context.Context, org model.Organization) error
 	GetOrgByID(ctx context.Context, id model.OrgID) (model.Organization, error)
-	GetOrgBySlug(ctx context.Context, slug string) (model.Organization, error)
+	// GetOrgBySlug resolves an organization within a tenant. Slugs are only
+	// unique per tenant, so the tenant is part of the key, never optional.
+	GetOrgBySlug(ctx context.Context, tenantID model.TenantID, slug string) (model.Organization, error)
 	ListOrgs(ctx context.Context, opts ListOrgsOptions) ([]model.Organization, int64, error)
 	SaveOrg(ctx context.Context, org model.Organization) error
 	DeleteOrg(ctx context.Context, id model.OrgID) error
@@ -28,6 +30,11 @@ type OrgStore interface {
 type ListOrgsOptions struct {
 	Page  *int
 	Limit *int
+
+	// TenantID restricts the listing to a single tenant. A nil value spans the
+	// whole instance and must stay reserved for maintenance loops that
+	// legitimately cross tenants.
+	TenantID *model.TenantID
 }
 
 type ListOrgMembersOptions struct {

--- a/internal/core/port/tenant_store.go
+++ b/internal/core/port/tenant_store.go
@@ -1,0 +1,28 @@
+package port
+
+import (
+	"context"
+
+	"github.com/xolo-gateway/xolo/internal/core/model"
+)
+
+// TenantStore persists the outermost isolation boundary. Tenant slugs are
+// unique instance-wide: in multi-tenant mode they are the hostname label used
+// to route a request, so two tenants can never share one.
+type TenantStore interface {
+	CreateTenant(ctx context.Context, tenant model.Tenant) error
+	GetTenantByID(ctx context.Context, id model.TenantID) (model.Tenant, error)
+	GetTenantBySlug(ctx context.Context, slug string) (model.Tenant, error)
+	ListTenants(ctx context.Context, opts ListTenantsOptions) ([]model.Tenant, int64, error)
+	SaveTenant(ctx context.Context, tenant model.Tenant) error
+
+	// DeleteTenant removes the tenant and everything it owns: every
+	// organization with its whole org-scoped footprint, then every user of the
+	// tenant and its dependencies.
+	DeleteTenant(ctx context.Context, id model.TenantID) error
+}
+
+type ListTenantsOptions struct {
+	Page  *int
+	Limit *int
+}

--- a/internal/core/port/user_store.go
+++ b/internal/core/port/user_store.go
@@ -7,17 +7,18 @@ import (
 )
 
 type UserStore interface {
-	// FindOrCreateUser searches for a User in the store by its provider/subject unique tuple and returns
-	// it if it exists, or create a new one otherwise
-	FindOrCreateUser(ctx context.Context, provider, subject string) (model.User, error)
+	// FindOrCreateUser searches for a User in the store by its
+	// tenant/provider/subject unique tuple and returns it if it exists, or
+	// creates a new one otherwise.
+	FindOrCreateUser(ctx context.Context, tenantID model.TenantID, provider, subject string) (model.User, error)
 
 	// GetUserByID finds a user by its ID, or returns ErrNotFound if not found
 	GetUserByID(ctx context.Context, userID model.UserID) (model.User, error)
 
-	// GetUserByIdentity finds a user by its provider/subject unique tuple, or
-	// returns ErrNotFound if not found. Unlike FindOrCreateUser, it never
-	// creates anything.
-	GetUserByIdentity(ctx context.Context, provider, subject string) (model.User, error)
+	// GetUserByIdentity finds a user by its tenant/provider/subject unique
+	// tuple, or returns ErrNotFound if not found. Unlike FindOrCreateUser, it
+	// never creates anything.
+	GetUserByIdentity(ctx context.Context, tenantID model.TenantID, provider, subject string) (model.User, error)
 
 	// QueryUsers returns a paginated list of users
 	QueryUsers(ctx context.Context, opts QueryUsersOptions) ([]model.User, error)
@@ -49,6 +50,11 @@ type QueryUsersOptions struct {
 	Limit *int
 
 	// Filters
+
+	// TenantID restricts the result to a single tenant. A nil value spans the
+	// whole instance and must stay reserved for maintenance loops that
+	// legitimately cross tenants.
+	TenantID *model.TenantID
 
 	// Users with specific roles
 	Roles []string

--- a/internal/core/service/provisioning.go
+++ b/internal/core/service/provisioning.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"log/slog"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -15,17 +14,23 @@ import (
 )
 
 // ProvisioningService orchestrates the multi-store workflows needed to
-// provision organizations ("tenants" in the machine-to-machine vocabulary),
-// their members and their roles.
+// provision tenants, the organizations they own, their members and their roles.
 //
 // It is the single place where the invariants spanning several stores are
 // enforced: an organization always gets its builtin roles, it never loses its
-// last owner, roles are never assigned across organizations, and provisioning a
-// tenant administrator never grants platform-wide privileges.
+// last owner, roles are never assigned across organizations, users never cross
+// a tenant boundary, and provisioning an organization administrator never
+// grants platform-wide privileges.
 type ProvisioningService struct {
-	orgStore  port.OrgStore
-	userStore port.UserStore
-	roleStore port.RoleStore
+	tenantStore port.TenantStore
+	orgStore    port.OrgStore
+	userStore   port.UserStore
+	roleStore   port.RoleStore
+
+	// multiTenant reports whether the instance may hold more than one tenant.
+	// When false, the API serves the single default tenant but refuses to
+	// create another one.
+	multiTenant bool
 
 	// reservedEmails lists the addresses the API must never write on a user.
 	// They are the instance's default administrators: the authentication bridge
@@ -49,11 +54,21 @@ func WithReservedEmails(emails ...string) ProvisioningServiceOptionFunc {
 	}
 }
 
-func NewProvisioningService(orgStore port.OrgStore, userStore port.UserStore, roleStore port.RoleStore, funcs ...ProvisioningServiceOptionFunc) *ProvisioningService {
+// WithMultiTenant allows the service to provision more than one tenant. It
+// mirrors XOLO_MULTITENANCY_ENABLED: on a single-tenant instance, creating a
+// second tenant would produce organizations no hostname can ever reach.
+func WithMultiTenant(enabled bool) ProvisioningServiceOptionFunc {
+	return func(s *ProvisioningService) {
+		s.multiTenant = enabled
+	}
+}
+
+func NewProvisioningService(tenantStore port.TenantStore, orgStore port.OrgStore, userStore port.UserStore, roleStore port.RoleStore, funcs ...ProvisioningServiceOptionFunc) *ProvisioningService {
 	s := &ProvisioningService{
-		orgStore:  orgStore,
-		userStore: userStore,
-		roleStore: roleStore,
+		tenantStore: tenantStore,
+		orgStore:    orgStore,
+		userStore:   userStore,
+		roleStore:   roleStore,
 	}
 
 	for _, fn := range funcs {
@@ -61,6 +76,138 @@ func NewProvisioningService(orgStore port.OrgStore, userStore port.UserStore, ro
 	}
 
 	return s
+}
+
+type CreateTenantParams struct {
+	Slug        string
+	Name        string
+	Description string
+	Active      *bool
+}
+
+// CreateTenant creates a tenant. It is refused on a single-tenant instance:
+// without multi-tenancy no hostname resolves to a second tenant, so its
+// organizations would be unreachable.
+func (s *ProvisioningService) CreateTenant(ctx context.Context, params CreateTenantParams) (model.Tenant, error) {
+	if !s.multiTenant {
+		return nil, errors.Wrap(port.ErrNotAllowed, "this instance runs in single-tenant mode; set XOLO_MULTITENANCY_ENABLED=true to provision additional tenants")
+	}
+
+	if err := validateSlug(params.Slug); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	name := strings.TrimSpace(params.Name)
+	if name == "" {
+		return nil, errors.Wrap(port.ErrInvalid, "name is required")
+	}
+
+	// Explicit pre-check so the conflict carries the existing identifier, which
+	// is what an external reconciler needs. The unique constraint on the slug
+	// remains the authoritative backstop.
+	if existing, err := s.tenantStore.GetTenantBySlug(ctx, params.Slug); err == nil {
+		return nil, errors.Wrapf(port.ErrAlreadyExists, "tenant with slug %q already exists (id: %s)", params.Slug, existing.ID())
+	} else if !errors.Is(err, port.ErrNotFound) {
+		return nil, errors.WithStack(err)
+	}
+
+	tenant := model.NewTenant(params.Slug, name, strings.TrimSpace(params.Description))
+	if params.Active != nil {
+		tenant = model.UpdateTenant(tenant, model.WithTenantActive(*params.Active))
+	}
+
+	if err := s.tenantStore.CreateTenant(ctx, tenant); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return tenant, nil
+}
+
+func (s *ProvisioningService) GetTenant(ctx context.Context, tenantID model.TenantID) (model.Tenant, error) {
+	tenant, err := s.tenantStore.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return tenant, nil
+}
+
+func (s *ProvisioningService) GetTenantBySlug(ctx context.Context, slug string) (model.Tenant, error) {
+	tenant, err := s.tenantStore.GetTenantBySlug(ctx, slug)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return tenant, nil
+}
+
+func (s *ProvisioningService) ListTenants(ctx context.Context, opts port.ListTenantsOptions) ([]model.Tenant, int64, error) {
+	tenants, total, err := s.tenantStore.ListTenants(ctx, opts)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	return tenants, total, nil
+}
+
+type UpdateTenantParams struct {
+	Name        *string
+	Description *string
+	Active      *bool
+}
+
+// UpdateTenant applies the provided fields to an existing tenant. The slug is
+// immutable: it is the stable handle external systems reconcile on, and in
+// multi-tenant mode it is also the hostname label routing to the tenant.
+func (s *ProvisioningService) UpdateTenant(ctx context.Context, tenantID model.TenantID, params UpdateTenantParams) (model.Tenant, error) {
+	tenant, err := s.tenantStore.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	opts := make([]model.TenantOption, 0, 3)
+
+	if params.Name != nil {
+		name := strings.TrimSpace(*params.Name)
+		if name == "" {
+			return nil, errors.Wrap(port.ErrInvalid, "name can not be empty")
+		}
+		opts = append(opts, model.WithTenantName(name))
+	}
+	if params.Description != nil {
+		opts = append(opts, model.WithTenantDescription(strings.TrimSpace(*params.Description)))
+	}
+	if params.Active != nil {
+		if !*params.Active && tenant.Slug() == model.DefaultTenantSlug {
+			return nil, errors.Wrap(port.ErrNotAllowed, "the default tenant can not be deactivated")
+		}
+		opts = append(opts, model.WithTenantActive(*params.Active))
+	}
+
+	updated := model.UpdateTenant(tenant, opts...)
+
+	if err := s.tenantStore.SaveTenant(ctx, updated); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return updated, nil
+}
+
+// DeleteTenant removes a tenant and everything it owns. The default tenant is
+// never deletable: it is the fallback every single-tenant instance resolves to,
+// and losing it would leave the instance unusable.
+func (s *ProvisioningService) DeleteTenant(ctx context.Context, tenantID model.TenantID) error {
+	tenant, err := s.tenantStore.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if tenant.Slug() == model.DefaultTenantSlug {
+		return errors.Wrap(port.ErrNotAllowed, "the default tenant can not be deleted")
+	}
+
+	if err := s.tenantStore.DeleteTenant(ctx, tenantID); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }
 
 // assertEmailAllowed rejects an email reserved for the instance administrators.
@@ -77,12 +224,6 @@ func (s *ProvisioningService) assertEmailAllowed(email *string) error {
 	return nil
 }
 
-// slugPattern matches a DNS-label-like identifier, the form external systems
-// (Kubernetes operators, Terraform providers) can always produce.
-var slugPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
-
-const maxSlugLength = 63
-
 // UserIdentityParams describes a user by its authentication identity. The
 // provider/subject tuple is required: it is the same key interactive
 // authentication uses, so a provisioned user can log in afterwards. No
@@ -95,7 +236,8 @@ type UserIdentityParams struct {
 	Active      *bool
 }
 
-type CreateTenantParams struct {
+type CreateOrganizationParams struct {
+	TenantID    model.TenantID
 	Slug        string
 	Name        string
 	Description string
@@ -103,11 +245,11 @@ type CreateTenantParams struct {
 	Active      *bool
 
 	// Owner, when set, is provisioned and granted the builtin owner role of the
-	// new tenant.
+	// new organization.
 	Owner *UserIdentityParams
 }
 
-type CreateTenantResult struct {
+type CreateOrganizationResult struct {
 	Org model.Organization
 
 	// Owner and OwnerMembership are nil when no initial owner was requested.
@@ -119,14 +261,14 @@ type CreateTenantResult struct {
 	OwnerCreated bool
 }
 
-// CreateTenant creates an organization, its builtin roles and, optionally, its
+// CreateOrganization creates an organization, its builtin roles and, optionally, its
 // initial owner.
 //
 // The stores expose no cross-store transaction, so any failure occurring after
 // the organization row exists triggers a best-effort compensation: the
 // organization is deleted (memberships cascade) to avoid leaving a half
-// provisioned tenant behind. A pre-existing user is never deleted.
-func (s *ProvisioningService) CreateTenant(ctx context.Context, params CreateTenantParams) (*CreateTenantResult, error) {
+// provisioned organization behind. A pre-existing user is never deleted.
+func (s *ProvisioningService) CreateOrganization(ctx context.Context, params CreateOrganizationParams) (*CreateOrganizationResult, error) {
 	if err := validateSlug(params.Slug); err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -147,16 +289,16 @@ func (s *ProvisioningService) CreateTenant(ctx context.Context, params CreateTen
 		}
 	}
 
-	// Explicit pre-check so the conflict carries the existing tenant identifier,
+	// Explicit pre-check so the conflict carries the existing organization identifier,
 	// which is what an external reconciler needs. The unique constraint on the
 	// slug remains the authoritative backstop.
-	if existing, err := s.orgStore.GetOrgBySlug(ctx, params.Slug); err == nil {
-		return nil, errors.Wrapf(port.ErrAlreadyExists, "tenant with slug %q already exists (id: %s)", params.Slug, existing.ID())
+	if existing, err := s.orgStore.GetOrgBySlug(ctx, params.TenantID, params.Slug); err == nil {
+		return nil, errors.Wrapf(port.ErrAlreadyExists, "organization with slug %q already exists in this tenant (id: %s)", params.Slug, existing.ID())
 	} else if !errors.Is(err, port.ErrNotFound) {
 		return nil, errors.WithStack(err)
 	}
 
-	org := model.NewOrganization(params.Slug, name, strings.TrimSpace(params.Description), currency)
+	org := model.NewOrganization(params.TenantID, params.Slug, name, strings.TrimSpace(params.Description), currency)
 	if params.Active != nil {
 		org = model.UpdateOrganization(org, model.WithOrgActive(*params.Active))
 	}
@@ -165,29 +307,29 @@ func (s *ProvisioningService) CreateTenant(ctx context.Context, params CreateTen
 		return nil, errors.WithStack(err)
 	}
 
-	result, err := s.completeTenantCreation(ctx, org, params.Owner)
+	result, err := s.completeOrganizationCreation(ctx, org, params.Owner)
 	if err != nil {
-		s.rollbackTenant(ctx, org.ID())
+		s.rollbackOrganization(ctx, org.ID())
 		return nil, errors.WithStack(err)
 	}
 
 	return result, nil
 }
 
-// completeTenantCreation performs every step following the organization
+// completeOrganizationCreation performs every step following the organization
 // insertion. It is split out so the caller can compensate on any failure.
-func (s *ProvisioningService) completeTenantCreation(ctx context.Context, org model.Organization, owner *UserIdentityParams) (*CreateTenantResult, error) {
+func (s *ProvisioningService) completeOrganizationCreation(ctx context.Context, org model.Organization, owner *UserIdentityParams) (*CreateOrganizationResult, error) {
 	if err := s.roleStore.EnsureBuiltinRoles(ctx, org.ID()); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	result := &CreateTenantResult{Org: org}
+	result := &CreateOrganizationResult{Org: org}
 
 	if owner == nil {
 		return result, nil
 	}
 
-	user, created, err := s.ProvisionUser(ctx, *owner)
+	user, created, err := s.ProvisionUser(ctx, org.TenantID(), *owner)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -219,32 +361,40 @@ func (s *ProvisioningService) completeTenantCreation(ctx context.Context, org mo
 	return result, nil
 }
 
-// rollbackTenant compensates a partially created tenant. Failures are logged
+// rollbackOrganization compensates a partially created organization. Failures are logged
 // rather than returned: the caller is already reporting the original error.
-func (s *ProvisioningService) rollbackTenant(ctx context.Context, orgID model.OrgID) {
+func (s *ProvisioningService) rollbackOrganization(ctx context.Context, orgID model.OrgID) {
 	if err := s.orgStore.DeleteOrg(ctx, orgID); err != nil {
-		slog.ErrorContext(ctx, "could not rollback partially created tenant",
+		slog.ErrorContext(ctx, "could not rollback partially created organization",
 			slog.String("orgID", string(orgID)), slogx.Error(errors.WithStack(err)))
 	}
 }
 
-func (s *ProvisioningService) GetTenant(ctx context.Context, orgID model.OrgID) (model.Organization, error) {
+// GetOrganization returns an organization scoped to the given tenant. An
+// organization belonging to another tenant is reported as not found: the
+// Provisionning API must not let a caller probe another tenant's identifiers.
+func (s *ProvisioningService) GetOrganization(ctx context.Context, tenantID model.TenantID, orgID model.OrgID) (model.Organization, error) {
 	org, err := s.orgStore.GetOrgByID(ctx, orgID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	if org.TenantID() != tenantID {
+		return nil, errors.Wrapf(port.ErrNotFound, "organization %q does not belong to tenant %q", orgID, tenantID)
+	}
+
 	return org, nil
 }
 
-func (s *ProvisioningService) GetTenantBySlug(ctx context.Context, slug string) (model.Organization, error) {
-	org, err := s.orgStore.GetOrgBySlug(ctx, slug)
+func (s *ProvisioningService) GetOrganizationBySlug(ctx context.Context, tenantID model.TenantID, slug string) (model.Organization, error) {
+	org, err := s.orgStore.GetOrgBySlug(ctx, tenantID, slug)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return org, nil
 }
 
-func (s *ProvisioningService) ListTenants(ctx context.Context, opts port.ListOrgsOptions) ([]model.Organization, int64, error) {
+func (s *ProvisioningService) ListOrganizations(ctx context.Context, opts port.ListOrgsOptions) ([]model.Organization, int64, error) {
 	orgs, total, err := s.orgStore.ListOrgs(ctx, opts)
 	if err != nil {
 		return nil, 0, errors.WithStack(err)
@@ -252,7 +402,7 @@ func (s *ProvisioningService) ListTenants(ctx context.Context, opts port.ListOrg
 	return orgs, total, nil
 }
 
-type UpdateTenantParams struct {
+type UpdateOrganizationParams struct {
 	Name              *string
 	Description       *string
 	Active            *bool
@@ -260,10 +410,10 @@ type UpdateTenantParams struct {
 	ShareQuotaEqually *bool
 }
 
-// UpdateTenant applies the provided fields to an existing tenant. The slug is
+// UpdateOrganization applies the provided fields to an existing organization. The slug is
 // immutable: it is the stable handle external systems reconcile on.
-func (s *ProvisioningService) UpdateTenant(ctx context.Context, orgID model.OrgID, params UpdateTenantParams) (model.Organization, error) {
-	org, err := s.orgStore.GetOrgByID(ctx, orgID)
+func (s *ProvisioningService) UpdateOrganization(ctx context.Context, tenantID model.TenantID, orgID model.OrgID, params UpdateOrganizationParams) (model.Organization, error) {
+	org, err := s.GetOrganization(ctx, tenantID, orgID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -303,7 +453,11 @@ func (s *ProvisioningService) UpdateTenant(ctx context.Context, orgID model.OrgI
 	return updated, nil
 }
 
-func (s *ProvisioningService) DeleteTenant(ctx context.Context, orgID model.OrgID) error {
+func (s *ProvisioningService) DeleteOrganization(ctx context.Context, tenantID model.TenantID, orgID model.OrgID) error {
+	if _, err := s.GetOrganization(ctx, tenantID, orgID); err != nil {
+		return errors.WithStack(err)
+	}
+
 	if err := s.orgStore.DeleteOrg(ctx, orgID); err != nil {
 		return errors.WithStack(err)
 	}
@@ -314,9 +468,9 @@ func (s *ProvisioningService) DeleteTenant(ctx context.Context, orgID model.OrgI
 // it if needed, and reports whether it was created.
 //
 // A newly created user receives exactly the "user" platform role: administering
-// a tenant must never turn into administering the Xolo instance. The platform
+// an organization must never turn into administering the Xolo instance. The platform
 // roles of an already known user are never modified here.
-func (s *ProvisioningService) ProvisionUser(ctx context.Context, params UserIdentityParams) (model.User, bool, error) {
+func (s *ProvisioningService) ProvisionUser(ctx context.Context, tenantID model.TenantID, params UserIdentityParams) (model.User, bool, error) {
 	if err := validateIdentity(params); err != nil {
 		return nil, false, errors.WithStack(err)
 	}
@@ -325,7 +479,7 @@ func (s *ProvisioningService) ProvisionUser(ctx context.Context, params UserIden
 		return nil, false, errors.WithStack(err)
 	}
 
-	existing, err := s.userStore.GetUserByIdentity(ctx, params.Provider, params.Subject)
+	existing, err := s.userStore.GetUserByIdentity(ctx, tenantID, params.Provider, params.Subject)
 	if err != nil && !errors.Is(err, port.ErrNotFound) {
 		return nil, false, errors.WithStack(err)
 	}
@@ -338,7 +492,7 @@ func (s *ProvisioningService) ProvisionUser(ctx context.Context, params UserIden
 		return updated, false, nil
 	}
 
-	created, err := s.userStore.FindOrCreateUser(ctx, params.Provider, params.Subject)
+	created, err := s.userStore.FindOrCreateUser(ctx, tenantID, params.Provider, params.Subject)
 	if err != nil {
 		return nil, false, errors.WithStack(err)
 	}
@@ -380,16 +534,23 @@ func (s *ProvisioningService) ProvisionUser(ctx context.Context, params UserIden
 	return user, fresh, nil
 }
 
-func (s *ProvisioningService) GetUser(ctx context.Context, userID model.UserID) (model.User, error) {
+// GetUser returns a user scoped to the given tenant. A user belonging to
+// another tenant is reported as not found.
+func (s *ProvisioningService) GetUser(ctx context.Context, tenantID model.TenantID, userID model.UserID) (model.User, error) {
 	user, err := s.userStore.GetUserByID(ctx, userID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	if user.TenantID() != tenantID {
+		return nil, errors.Wrapf(port.ErrNotFound, "user %q does not belong to tenant %q", userID, tenantID)
+	}
+
 	return user, nil
 }
 
-func (s *ProvisioningService) FindUserByIdentity(ctx context.Context, provider, subject string) (model.User, error) {
-	user, err := s.userStore.GetUserByIdentity(ctx, provider, subject)
+func (s *ProvisioningService) FindUserByIdentity(ctx context.Context, tenantID model.TenantID, provider, subject string) (model.User, error) {
+	user, err := s.userStore.GetUserByIdentity(ctx, tenantID, provider, subject)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -418,8 +579,8 @@ type UpdateUserParams struct {
 
 // UpdateUser updates the profile fields of a user. Platform roles are
 // deliberately not exposed: the Provisionning API never grants instance-wide privileges.
-func (s *ProvisioningService) UpdateUser(ctx context.Context, userID model.UserID, params UpdateUserParams) (model.User, error) {
-	user, err := s.userStore.GetUserByID(ctx, userID)
+func (s *ProvisioningService) UpdateUser(ctx context.Context, tenantID model.TenantID, userID model.UserID, params UpdateUserParams) (model.User, error) {
+	user, err := s.GetUser(ctx, tenantID, userID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -482,25 +643,25 @@ type AddMemberParams struct {
 	BuiltinRoles []string
 }
 
-// AddMember adds a user to a tenant and assigns its initial roles.
+// AddMember adds a user to an organization and assigns its initial roles. The
+// user is resolved within the organization's own tenant, which is what makes
+// cross-tenant membership impossible.
 func (s *ProvisioningService) AddMember(ctx context.Context, orgID model.OrgID, params AddMemberParams) (model.Membership, error) {
-	if _, err := s.orgStore.GetOrgByID(ctx, orgID); err != nil {
+	org, err := s.orgStore.GetOrgByID(ctx, orgID)
+	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	var (
-		user model.User
-		err  error
-	)
+	var user model.User
 
 	switch {
 	case params.UserID != "":
-		user, err = s.userStore.GetUserByID(ctx, params.UserID)
+		user, err = s.GetUser(ctx, org.TenantID(), params.UserID)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 	case params.User != nil:
-		user, _, err = s.ProvisionUser(ctx, *params.User)
+		user, _, err = s.ProvisionUser(ctx, org.TenantID(), *params.User)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -509,7 +670,7 @@ func (s *ProvisioningService) AddMember(ctx context.Context, orgID model.OrgID, 
 	}
 
 	if existing, err := s.orgStore.GetUserOrgMembership(ctx, user.ID(), orgID); err == nil {
-		return nil, errors.Wrapf(port.ErrAlreadyExists, "user is already a member of this tenant (membership id: %s)", existing.ID())
+		return nil, errors.Wrapf(port.ErrAlreadyExists, "user is already a member of this organization (membership id: %s)", existing.ID())
 	} else if !errors.Is(err, port.ErrNotFound) {
 		return nil, errors.WithStack(err)
 	}
@@ -555,9 +716,9 @@ func (s *ProvisioningService) ListMembers(ctx context.Context, orgID model.OrgID
 	return members, total, nil
 }
 
-// GetMember returns a membership scoped to the given tenant. A membership
-// belonging to another tenant is reported as not found: the Provisionning API must not
-// let a caller probe another tenant's identifiers.
+// GetMember returns a membership scoped to the given organization. A membership
+// belonging to another organization is reported as not found: the Provisionning API
+// must not let a caller probe another organization's identifiers.
 func (s *ProvisioningService) GetMember(ctx context.Context, orgID model.OrgID, membershipID model.MembershipID) (model.Membership, error) {
 	membership, err := s.orgStore.GetMembership(ctx, membershipID)
 	if err != nil {
@@ -565,14 +726,14 @@ func (s *ProvisioningService) GetMember(ctx context.Context, orgID model.OrgID, 
 	}
 
 	if membership.OrgID() != orgID {
-		return nil, errors.Wrapf(port.ErrNotFound, "membership %q does not belong to tenant %q", membershipID, orgID)
+		return nil, errors.Wrapf(port.ErrNotFound, "membership %q does not belong to organization %q", membershipID, orgID)
 	}
 
 	return membership, nil
 }
 
 // SetMemberRoles fully replaces the roles of a membership. Every role must
-// belong to the membership's tenant, and the tenant must keep at least one
+// belong to the membership's organization, and the organization must keep at least one
 // owner.
 func (s *ProvisioningService) SetMemberRoles(ctx context.Context, orgID model.OrgID, membershipID model.MembershipID, roleIDs []model.RoleID, builtinRoles []string) (model.Membership, error) {
 	membership, err := s.GetMember(ctx, orgID, membershipID)
@@ -635,8 +796,8 @@ func (s *ProvisioningService) ListRoles(ctx context.Context, orgID model.OrgID) 
 	return roles, nil
 }
 
-// GetRole returns a role scoped to the given tenant. A role belonging to
-// another tenant is reported as not found.
+// GetRole returns a role scoped to the given organization. A role belonging to
+// another organization is reported as not found.
 func (s *ProvisioningService) GetRole(ctx context.Context, orgID model.OrgID, roleID model.RoleID) (model.Role, error) {
 	role, err := s.roleStore.GetRoleByID(ctx, roleID)
 	if err != nil {
@@ -644,7 +805,7 @@ func (s *ProvisioningService) GetRole(ctx context.Context, orgID model.OrgID, ro
 	}
 
 	if role.OrgID() != orgID {
-		return nil, errors.Wrapf(port.ErrNotFound, "role %q does not belong to tenant %q", roleID, orgID)
+		return nil, errors.Wrapf(port.ErrNotFound, "role %q does not belong to organization %q", roleID, orgID)
 	}
 
 	return role, nil
@@ -755,7 +916,7 @@ func (s *ProvisioningService) DeleteRole(ctx context.Context, orgID model.OrgID,
 
 // resolveRoleIDs merges explicit role identifiers and builtin role kinds into a
 // deduplicated list, and verifies every resulting role belongs to orgID. This
-// is what makes cross-tenant role assignment impossible.
+// is what makes cross-organization role assignment impossible.
 func (s *ProvisioningService) resolveRoleIDs(ctx context.Context, orgID model.OrgID, roleIDs []model.RoleID, builtinKinds []string) ([]model.RoleID, error) {
 	if len(roleIDs) == 0 && len(builtinKinds) == 0 {
 		return nil, nil
@@ -788,7 +949,7 @@ func (s *ProvisioningService) resolveRoleIDs(ctx context.Context, orgID model.Or
 
 	for _, id := range roleIDs {
 		if _, ok := byID[id]; !ok {
-			return nil, errors.Wrapf(port.ErrInvalid, "role %q does not belong to tenant %q", id, orgID)
+			return nil, errors.Wrapf(port.ErrInvalid, "role %q does not belong to organization %q", id, orgID)
 		}
 		appendRole(id)
 	}
@@ -816,10 +977,10 @@ func (s *ProvisioningService) resolveBuiltinRole(ctx context.Context, orgID mode
 		}
 	}
 
-	return nil, errors.Wrapf(port.ErrNotFound, "no builtin %q role found for tenant %q", kind, orgID)
+	return nil, errors.Wrapf(port.ErrNotFound, "no builtin %q role found for organization %q", kind, orgID)
 }
 
-// assertNotLastOwner refuses an operation that would leave the tenant without
+// assertNotLastOwner refuses an operation that would leave the organization without
 // any owner.
 func (s *ProvisioningService) assertNotLastOwner(ctx context.Context, orgID model.OrgID, membershipID model.MembershipID) error {
 	members, _, err := s.orgStore.ListOrgMembers(ctx, orgID, port.ListOrgMembersOptions{})
@@ -828,7 +989,7 @@ func (s *ProvisioningService) assertNotLastOwner(ctx context.Context, orgID mode
 	}
 
 	if IsLastOwner(members, membershipID) {
-		return errors.Wrap(port.ErrNotAllowed, "a tenant must keep at least one owner")
+		return errors.Wrap(port.ErrNotAllowed, "an organization must keep at least one owner")
 	}
 
 	return nil
@@ -865,10 +1026,10 @@ func validateSlug(slug string) error {
 	if slug == "" {
 		return errors.Wrap(port.ErrInvalid, "slug is required")
 	}
-	if len(slug) > maxSlugLength {
-		return errors.Wrapf(port.ErrInvalid, "slug must be at most %d characters long", maxSlugLength)
+	if len(slug) > model.MaxSlugLength {
+		return errors.Wrapf(port.ErrInvalid, "slug must be at most %d characters long", model.MaxSlugLength)
 	}
-	if !slugPattern.MatchString(slug) {
+	if !model.SlugPattern.MatchString(slug) {
 		return errors.Wrap(port.ErrInvalid, "slug must only contain lowercase letters, digits and dashes, and must start and end with a letter or a digit")
 	}
 	return nil

--- a/internal/core/service/provisioning_test.go
+++ b/internal/core/service/provisioning_test.go
@@ -5,18 +5,18 @@ import (
 	"slices"
 	"testing"
 
+	_ "github.com/ncruces/go-sqlite3/embed"
+	"github.com/ncruces/go-sqlite3/gormlite"
+	"github.com/pkg/errors"
 	xologorm "github.com/xolo-gateway/xolo/internal/adapter/gorm"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
 	"github.com/xolo-gateway/xolo/internal/core/rbac"
 	"github.com/xolo-gateway/xolo/internal/core/service"
-	_ "github.com/ncruces/go-sqlite3/embed"
-	"github.com/ncruces/go-sqlite3/gormlite"
-	"github.com/pkg/errors"
 	gormpkg "gorm.io/gorm"
 )
 
-func newTestService(t *testing.T) (*service.ProvisioningService, *xologorm.Store) {
+func newTestService(t *testing.T) (*service.ProvisioningService, *xologorm.Store, model.TenantID) {
 	t.Helper()
 
 	db, err := gormpkg.Open(gormlite.Open(":memory:"), &gormpkg.Config{})
@@ -26,7 +26,17 @@ func newTestService(t *testing.T) (*service.ProvisioningService, *xologorm.Store
 
 	store := xologorm.NewStore(db)
 
-	return service.NewProvisioningService(store, store, store), store
+	// The schema migration creates the default tenant; every fixture of this
+	// package hangs from it, so the tests exercise organizations rather than
+	// tenancy.
+	tenant, err := store.GetTenantBySlug(context.Background(), model.DefaultTenantSlug)
+	if err != nil {
+		t.Fatalf("get default tenant: %v", err)
+	}
+
+	svc := service.NewProvisioningService(store, store, store, store)
+
+	return svc, store, tenant.ID()
 }
 
 func strPtr(v string) *string { return &v }
@@ -40,28 +50,30 @@ func ownerParams() *service.UserIdentityParams {
 	}
 }
 
-func createTenant(t *testing.T, svc *service.ProvisioningService, slug string, owner *service.UserIdentityParams) *service.CreateTenantResult {
+func createOrganization(t *testing.T, svc *service.ProvisioningService, tenantID model.TenantID, slug string, owner *service.UserIdentityParams) *service.CreateOrganizationResult {
 	t.Helper()
 
-	result, err := svc.CreateTenant(context.Background(), service.CreateTenantParams{
-		Slug:  slug,
-		Name:  slug,
-		Owner: owner,
+	result, err := svc.CreateOrganization(context.Background(), service.CreateOrganizationParams{
+		TenantID: tenantID,
+		Slug:     slug,
+		Name:     slug,
+		Owner:    owner,
 	})
 	if err != nil {
-		t.Fatalf("create tenant %q: %v", slug, err)
+		t.Fatalf("create organization %q: %v", slug, err)
 	}
 
 	return result
 }
 
-func TestCreateTenant(t *testing.T) {
+func TestCreateOrganization(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("provisions organization, builtin roles and initial owner", func(t *testing.T) {
-		svc, store := newTestService(t)
+		svc, store, testTenantID := newTestService(t)
 
-		result, err := svc.CreateTenant(ctx, service.CreateTenantParams{
+		result, err := svc.CreateOrganization(ctx, service.CreateOrganizationParams{
+			TenantID:    testTenantID,
 			Slug:        "acme",
 			Name:        "Acme",
 			Description: "Acme Inc.",
@@ -69,10 +81,10 @@ func TestCreateTenant(t *testing.T) {
 			Owner:       ownerParams(),
 		})
 		if err != nil {
-			t.Fatalf("create tenant: %v", err)
+			t.Fatalf("create organization: %v", err)
 		}
 
-		org, err := store.GetOrgBySlug(ctx, "acme")
+		org, err := store.GetOrgBySlug(ctx, testTenantID, "acme")
 		if err != nil {
 			t.Fatalf("get org by slug: %v", err)
 		}
@@ -133,10 +145,10 @@ func TestCreateTenant(t *testing.T) {
 		}
 	})
 
-	t.Run("tenant owner never becomes a platform admin", func(t *testing.T) {
-		svc, store := newTestService(t)
+	t.Run("organization owner never becomes a platform admin", func(t *testing.T) {
+		svc, store, testTenantID := newTestService(t)
 
-		result := createTenant(t, svc, "acme", ownerParams())
+		result := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
 		user, err := store.GetUserByID(ctx, result.Owner.ID())
 		if err != nil {
@@ -144,7 +156,7 @@ func TestCreateTenant(t *testing.T) {
 		}
 
 		if slices.Contains(user.Roles(), model.PlatformRoleAdmin) {
-			t.Fatalf("tenant owner must not hold the %q platform role, got %v", model.PlatformRoleAdmin, user.Roles())
+			t.Fatalf("organization owner must not hold the %q platform role, got %v", model.PlatformRoleAdmin, user.Roles())
 		}
 		if len(user.Roles()) != 1 || user.Roles()[0] != model.PlatformRoleUser {
 			t.Errorf("platform roles: got %v, want [%q]", user.Roles(), model.PlatformRoleUser)
@@ -152,9 +164,9 @@ func TestCreateTenant(t *testing.T) {
 	})
 
 	t.Run("existing user keeps its platform roles", func(t *testing.T) {
-		svc, store := newTestService(t)
+		svc, store, testTenantID := newTestService(t)
 
-		existing, err := store.FindOrCreateUser(ctx, "openid-connect", "sub-owner")
+		existing, err := store.FindOrCreateUser(ctx, testTenantID, "openid-connect", "sub-owner")
 		if err != nil {
 			t.Fatalf("find or create user: %v", err)
 		}
@@ -166,13 +178,14 @@ func TestCreateTenant(t *testing.T) {
 			t.Fatalf("save user: %v", err)
 		}
 
-		result, err := svc.CreateTenant(ctx, service.CreateTenantParams{
-			Slug:  "acme",
-			Name:  "Acme",
-			Owner: &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-owner"},
+		result, err := svc.CreateOrganization(ctx, service.CreateOrganizationParams{
+			TenantID: testTenantID,
+			Slug:     "acme",
+			Name:     "Acme",
+			Owner:    &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-owner"},
 		})
 		if err != nil {
-			t.Fatalf("create tenant: %v", err)
+			t.Fatalf("create organization: %v", err)
 		}
 
 		if result.OwnerCreated {
@@ -192,20 +205,20 @@ func TestCreateTenant(t *testing.T) {
 	})
 
 	t.Run("duplicate slug is refused", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		createTenant(t, svc, "acme", nil)
+		createOrganization(t, svc, testTenantID, "acme", nil)
 
-		_, err := svc.CreateTenant(ctx, service.CreateTenantParams{Slug: "acme", Name: "Acme again"})
+		_, err := svc.CreateOrganization(ctx, service.CreateOrganizationParams{TenantID: testTenantID, Slug: "acme", Name: "Acme again"})
 		if !errors.Is(err, port.ErrAlreadyExists) {
 			t.Errorf("error: got %v, want %v", err, port.ErrAlreadyExists)
 		}
 	})
 
 	t.Run("invalid input is refused", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		for name, params := range map[string]service.CreateTenantParams{
+		for name, params := range map[string]service.CreateOrganizationParams{
 			"malformed slug":   {Slug: "Acme Corp", Name: "Acme"},
 			"empty slug":       {Slug: "", Name: "Acme"},
 			"trailing dash":    {Slug: "acme-", Name: "Acme"},
@@ -214,90 +227,93 @@ func TestCreateTenant(t *testing.T) {
 			"owner no subject": {Slug: "acme", Name: "Acme", Owner: &service.UserIdentityParams{Provider: "openid-connect"}},
 		} {
 			t.Run(name, func(t *testing.T) {
-				if _, err := svc.CreateTenant(ctx, params); !errors.Is(err, port.ErrInvalid) {
+				params.TenantID = testTenantID
+				if _, err := svc.CreateOrganization(ctx, params); !errors.Is(err, port.ErrInvalid) {
 					t.Errorf("error: got %v, want %v", err, port.ErrInvalid)
 				}
 			})
 		}
 	})
 
-	t.Run("invalid owner leaves no tenant behind", func(t *testing.T) {
-		svc, store := newTestService(t)
+	t.Run("invalid owner leaves no organization behind", func(t *testing.T) {
+		svc, store, testTenantID := newTestService(t)
 
-		_, err := svc.CreateTenant(ctx, service.CreateTenantParams{
-			Slug:  "acme",
-			Name:  "Acme",
-			Owner: &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-1", Email: strPtr("dup@acme.tld")},
+		_, err := svc.CreateOrganization(ctx, service.CreateOrganizationParams{
+			TenantID: testTenantID,
+			Slug:     "acme",
+			Name:     "Acme",
+			Owner:    &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-1", Email: strPtr("dup@acme.tld")},
 		})
 		if err != nil {
-			t.Fatalf("create first tenant: %v", err)
+			t.Fatalf("create first organization: %v", err)
 		}
 
 		// The email is already taken by the first owner: provisioning must fail
-		// and the half-created tenant must be rolled back.
-		_, err = svc.CreateTenant(ctx, service.CreateTenantParams{
-			Slug:  "other",
-			Name:  "Other",
-			Owner: &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-2", Email: strPtr("dup@acme.tld")},
+		// and the half-created organization must be rolled back.
+		_, err = svc.CreateOrganization(ctx, service.CreateOrganizationParams{
+			TenantID: testTenantID,
+			Slug:     "other",
+			Name:     "Other",
+			Owner:    &service.UserIdentityParams{Provider: "openid-connect", Subject: "sub-2", Email: strPtr("dup@acme.tld")},
 		})
 		if !errors.Is(err, port.ErrAlreadyExists) {
 			t.Fatalf("error: got %v, want %v", err, port.ErrAlreadyExists)
 		}
 
-		if _, err := store.GetOrgBySlug(ctx, "other"); !errors.Is(err, port.ErrNotFound) {
-			t.Errorf("tenant should have been rolled back, got %v", err)
+		if _, err := store.GetOrgBySlug(ctx, testTenantID, "other"); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("organization should have been rolled back, got %v", err)
 		}
-		if _, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-2"); !errors.Is(err, port.ErrNotFound) {
+		if _, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-2"); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("user should have been rolled back, got %v", err)
 		}
 	})
 }
 
-func TestTenantLifecycle(t *testing.T) {
+func TestOrganizationLifecycle(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("update applies only the provided fields", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", nil)
+		org := createOrganization(t, svc, testTenantID, "acme", nil)
 
 		active := false
-		updated, err := svc.UpdateTenant(ctx, tenant.Org.ID(), service.UpdateTenantParams{
+		updated, err := svc.UpdateOrganization(ctx, testTenantID, org.Org.ID(), service.UpdateOrganizationParams{
 			Name:   strPtr("Acme Corporation"),
 			Active: &active,
 		})
 		if err != nil {
-			t.Fatalf("update tenant: %v", err)
+			t.Fatalf("update organization: %v", err)
 		}
 
 		if updated.Name() != "Acme Corporation" {
 			t.Errorf("name: got %q", updated.Name())
 		}
 		if updated.Active() {
-			t.Error("tenant should be inactive")
+			t.Error("organization should be inactive")
 		}
 		if updated.Slug() != "acme" {
 			t.Errorf("slug must be immutable, got %q", updated.Slug())
 		}
 	})
 
-	t.Run("delete removes the tenant and its dependents", func(t *testing.T) {
-		svc, store := newTestService(t)
+	t.Run("delete removes the organization and its dependents", func(t *testing.T) {
+		svc, store, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
-		if err := svc.DeleteTenant(ctx, tenant.Org.ID()); err != nil {
-			t.Fatalf("delete tenant: %v", err)
+		if err := svc.DeleteOrganization(ctx, testTenantID, org.Org.ID()); err != nil {
+			t.Fatalf("delete organization: %v", err)
 		}
 
-		if _, err := store.GetOrgByID(ctx, tenant.Org.ID()); !errors.Is(err, port.ErrNotFound) {
-			t.Errorf("tenant: got %v, want %v", err, port.ErrNotFound)
+		if _, err := store.GetOrgByID(ctx, org.Org.ID()); !errors.Is(err, port.ErrNotFound) {
+			t.Errorf("organization: got %v, want %v", err, port.ErrNotFound)
 		}
-		if _, err := store.GetMembership(ctx, tenant.OwnerMembership.ID()); !errors.Is(err, port.ErrNotFound) {
+		if _, err := store.GetMembership(ctx, org.OwnerMembership.ID()); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("membership: got %v, want %v", err, port.ErrNotFound)
 		}
 
-		roles, err := store.ListOrgRoles(ctx, tenant.Org.ID())
+		roles, err := store.ListOrgRoles(ctx, org.Org.ID())
 		if err != nil {
 			t.Fatalf("list org roles: %v", err)
 		}
@@ -306,16 +322,16 @@ func TestTenantLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown tenant is reported as not found", func(t *testing.T) {
-		svc, _ := newTestService(t)
+	t.Run("unknown organization is reported as not found", func(t *testing.T) {
+		svc, _, testTenantID := newTestService(t)
 
-		if _, err := svc.GetTenant(ctx, model.OrgID("does-not-exist")); !errors.Is(err, port.ErrNotFound) {
+		if _, err := svc.GetOrganization(ctx, testTenantID, model.OrgID("does-not-exist")); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("get: got %v, want %v", err, port.ErrNotFound)
 		}
-		if _, err := svc.UpdateTenant(ctx, model.OrgID("does-not-exist"), service.UpdateTenantParams{}); !errors.Is(err, port.ErrNotFound) {
+		if _, err := svc.UpdateOrganization(ctx, testTenantID, model.OrgID("does-not-exist"), service.UpdateOrganizationParams{}); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("update: got %v, want %v", err, port.ErrNotFound)
 		}
-		if err := svc.DeleteTenant(ctx, model.OrgID("does-not-exist")); !errors.Is(err, port.ErrNotFound) {
+		if err := svc.DeleteOrganization(ctx, testTenantID, model.OrgID("does-not-exist")); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("delete: got %v, want %v", err, port.ErrNotFound)
 		}
 	})
@@ -334,11 +350,11 @@ func TestMembers(t *testing.T) {
 	}
 
 	t.Run("adds a member with builtin roles", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
-		membership, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{
+		membership, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{
 			User:         memberParams("sub-member"),
 			BuiltinRoles: []string{model.BuiltinKindMember},
 		})
@@ -352,42 +368,42 @@ func TestMembers(t *testing.T) {
 	})
 
 	t.Run("refuses a duplicate membership", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
-		if _, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{User: memberParams("sub-member")}); err != nil {
+		if _, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{User: memberParams("sub-member")}); err != nil {
 			t.Fatalf("add member: %v", err)
 		}
 
-		_, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{User: memberParams("sub-member")})
+		_, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{User: memberParams("sub-member")})
 		if !errors.Is(err, port.ErrAlreadyExists) {
 			t.Errorf("error: got %v, want %v", err, port.ErrAlreadyExists)
 		}
 	})
 
-	t.Run("refuses an unknown tenant or user", func(t *testing.T) {
-		svc, _ := newTestService(t)
+	t.Run("refuses an unknown organization or user", func(t *testing.T) {
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
 		if _, err := svc.AddMember(ctx, model.OrgID("nope"), service.AddMemberParams{User: memberParams("sub-member")}); !errors.Is(err, port.ErrNotFound) {
-			t.Errorf("unknown tenant: got %v, want %v", err, port.ErrNotFound)
+			t.Errorf("unknown organization: got %v, want %v", err, port.ErrNotFound)
 		}
-		if _, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{UserID: model.UserID("nope")}); !errors.Is(err, port.ErrNotFound) {
+		if _, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{UserID: model.UserID("nope")}); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("unknown user: got %v, want %v", err, port.ErrNotFound)
 		}
-		if _, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{}); !errors.Is(err, port.ErrInvalid) {
+		if _, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{}); !errors.Is(err, port.ErrInvalid) {
 			t.Errorf("missing identity: got %v, want %v", err, port.ErrInvalid)
 		}
 	})
 
 	t.Run("replaces member roles", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
-		membership, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{
+		membership, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{
 			User:         memberParams("sub-member"),
 			BuiltinRoles: []string{model.BuiltinKindMember},
 		})
@@ -395,7 +411,7 @@ func TestMembers(t *testing.T) {
 			t.Fatalf("add member: %v", err)
 		}
 
-		updated, err := svc.SetMemberRoles(ctx, tenant.Org.ID(), membership.ID(), nil, []string{model.BuiltinKindAdmin})
+		updated, err := svc.SetMemberRoles(ctx, org.Org.ID(), membership.ID(), nil, []string{model.BuiltinKindAdmin})
 		if err != nil {
 			t.Fatalf("set member roles: %v", err)
 		}
@@ -405,11 +421,11 @@ func TestMembers(t *testing.T) {
 		}
 	})
 
-	t.Run("refuses a role belonging to another tenant", func(t *testing.T) {
-		svc, _ := newTestService(t)
+	t.Run("refuses a role belonging to another organization", func(t *testing.T) {
+		svc, _, testTenantID := newTestService(t)
 
-		acme := createTenant(t, svc, "acme", ownerParams())
-		other := createTenant(t, svc, "other", nil)
+		acme := createOrganization(t, svc, testTenantID, "acme", ownerParams())
+		other := createOrganization(t, svc, testTenantID, "other", nil)
 
 		otherRoles, err := svc.ListRoles(ctx, other.Org.ID())
 		if err != nil {
@@ -439,43 +455,43 @@ func TestMembers(t *testing.T) {
 	})
 
 	t.Run("refuses to drop the last owner", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
-		ownerMembership := tenant.OwnerMembership
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
+		ownerMembership := org.OwnerMembership
 
-		_, err := svc.SetMemberRoles(ctx, tenant.Org.ID(), ownerMembership.ID(), nil, []string{model.BuiltinKindMember})
+		_, err := svc.SetMemberRoles(ctx, org.Org.ID(), ownerMembership.ID(), nil, []string{model.BuiltinKindMember})
 		if !errors.Is(err, port.ErrNotAllowed) {
 			t.Errorf("downgrade: got %v, want %v", err, port.ErrNotAllowed)
 		}
 
-		if err := svc.RemoveMember(ctx, tenant.Org.ID(), ownerMembership.ID()); !errors.Is(err, port.ErrNotAllowed) {
+		if err := svc.RemoveMember(ctx, org.Org.ID(), ownerMembership.ID()); !errors.Is(err, port.ErrNotAllowed) {
 			t.Errorf("removal: got %v, want %v", err, port.ErrNotAllowed)
 		}
 	})
 
 	t.Run("allows dropping an owner when another one remains", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", ownerParams())
+		org := createOrganization(t, svc, testTenantID, "acme", ownerParams())
 
-		if _, err := svc.AddMember(ctx, tenant.Org.ID(), service.AddMemberParams{
+		if _, err := svc.AddMember(ctx, org.Org.ID(), service.AddMemberParams{
 			User:         memberParams("sub-second-owner"),
 			BuiltinRoles: []string{model.BuiltinKindOwner},
 		}); err != nil {
 			t.Fatalf("add second owner: %v", err)
 		}
 
-		if err := svc.RemoveMember(ctx, tenant.Org.ID(), tenant.OwnerMembership.ID()); err != nil {
+		if err := svc.RemoveMember(ctx, org.Org.ID(), org.OwnerMembership.ID()); err != nil {
 			t.Fatalf("remove first owner: %v", err)
 		}
 	})
 
-	t.Run("hides a membership belonging to another tenant", func(t *testing.T) {
-		svc, _ := newTestService(t)
+	t.Run("hides a membership belonging to another organization", func(t *testing.T) {
+		svc, _, testTenantID := newTestService(t)
 
-		acme := createTenant(t, svc, "acme", ownerParams())
-		other := createTenant(t, svc, "other", nil)
+		acme := createOrganization(t, svc, testTenantID, "acme", ownerParams())
+		other := createOrganization(t, svc, testTenantID, "other", nil)
 
 		if _, err := svc.GetMember(ctx, other.Org.ID(), acme.OwnerMembership.ID()); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("get: got %v, want %v", err, port.ErrNotFound)
@@ -493,11 +509,11 @@ func TestRoles(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates and updates a custom role", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", nil)
+		org := createOrganization(t, svc, testTenantID, "acme", nil)
 
-		role, err := svc.CreateRole(ctx, tenant.Org.ID(), service.RoleParams{
+		role, err := svc.CreateRole(ctx, org.Org.ID(), service.RoleParams{
 			Name:        strPtr("auditor"),
 			Description: strPtr("Read-only access"),
 			Permissions: []string{string(rbac.PermUsageRead)},
@@ -506,7 +522,7 @@ func TestRoles(t *testing.T) {
 			t.Fatalf("create role: %v", err)
 		}
 
-		updated, err := svc.UpdateRole(ctx, tenant.Org.ID(), role.ID(), service.RoleParams{
+		updated, err := svc.UpdateRole(ctx, org.Org.ID(), role.ID(), service.RoleParams{
 			Permissions: []string{string(rbac.PermUsageRead), string(rbac.PermMembersRead)},
 		})
 		if err != nil {
@@ -516,17 +532,17 @@ func TestRoles(t *testing.T) {
 			t.Errorf("permissions: got %v", updated.Permissions())
 		}
 
-		if err := svc.DeleteRole(ctx, tenant.Org.ID(), role.ID()); err != nil {
+		if err := svc.DeleteRole(ctx, org.Org.ID(), role.ID()); err != nil {
 			t.Fatalf("delete role: %v", err)
 		}
 	})
 
 	t.Run("refuses an unknown permission or grant kind", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", nil)
+		org := createOrganization(t, svc, testTenantID, "acme", nil)
 
-		_, err := svc.CreateRole(ctx, tenant.Org.ID(), service.RoleParams{
+		_, err := svc.CreateRole(ctx, org.Org.ID(), service.RoleParams{
 			Name:        strPtr("bogus"),
 			Permissions: []string{"not:a:permission"},
 		})
@@ -534,7 +550,7 @@ func TestRoles(t *testing.T) {
 			t.Errorf("permission: got %v, want %v", err, port.ErrInvalid)
 		}
 
-		_, err = svc.CreateRole(ctx, tenant.Org.ID(), service.RoleParams{
+		_, err = svc.CreateRole(ctx, org.Org.ID(), service.RoleParams{
 			Name:        strPtr("bogus"),
 			ModelGrants: []model.ModelGrant{{ModelID: "m1", Kind: "wat"}},
 		})
@@ -544,26 +560,26 @@ func TestRoles(t *testing.T) {
 	})
 
 	t.Run("refuses a duplicate role name", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", nil)
+		org := createOrganization(t, svc, testTenantID, "acme", nil)
 
-		if _, err := svc.CreateRole(ctx, tenant.Org.ID(), service.RoleParams{Name: strPtr("auditor")}); err != nil {
+		if _, err := svc.CreateRole(ctx, org.Org.ID(), service.RoleParams{Name: strPtr("auditor")}); err != nil {
 			t.Fatalf("create role: %v", err)
 		}
 
-		_, err := svc.CreateRole(ctx, tenant.Org.ID(), service.RoleParams{Name: strPtr("auditor")})
+		_, err := svc.CreateRole(ctx, org.Org.ID(), service.RoleParams{Name: strPtr("auditor")})
 		if !errors.Is(err, port.ErrAlreadyExists) {
 			t.Errorf("error: got %v, want %v", err, port.ErrAlreadyExists)
 		}
 	})
 
 	t.Run("refuses to modify or delete a builtin role", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		tenant := createTenant(t, svc, "acme", nil)
+		org := createOrganization(t, svc, testTenantID, "acme", nil)
 
-		roles, err := svc.ListRoles(ctx, tenant.Org.ID())
+		roles, err := svc.ListRoles(ctx, org.Org.ID())
 		if err != nil {
 			t.Fatalf("list roles: %v", err)
 		}
@@ -578,19 +594,19 @@ func TestRoles(t *testing.T) {
 			t.Fatal("no builtin owner role found")
 		}
 
-		if _, err := svc.UpdateRole(ctx, tenant.Org.ID(), builtin.ID(), service.RoleParams{Name: strPtr("hacked")}); !errors.Is(err, port.ErrNotAllowed) {
+		if _, err := svc.UpdateRole(ctx, org.Org.ID(), builtin.ID(), service.RoleParams{Name: strPtr("hacked")}); !errors.Is(err, port.ErrNotAllowed) {
 			t.Errorf("update: got %v, want %v", err, port.ErrNotAllowed)
 		}
-		if err := svc.DeleteRole(ctx, tenant.Org.ID(), builtin.ID()); !errors.Is(err, port.ErrNotAllowed) {
+		if err := svc.DeleteRole(ctx, org.Org.ID(), builtin.ID()); !errors.Is(err, port.ErrNotAllowed) {
 			t.Errorf("delete: got %v, want %v", err, port.ErrNotAllowed)
 		}
 	})
 
 	t.Run("hides a role belonging to another tenant", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		acme := createTenant(t, svc, "acme", nil)
-		other := createTenant(t, svc, "other", nil)
+		acme := createOrganization(t, svc, testTenantID, "acme", nil)
+		other := createOrganization(t, svc, testTenantID, "other", nil)
 
 		otherRoles, err := svc.ListRoles(ctx, other.Org.ID())
 		if err != nil {
@@ -607,9 +623,9 @@ func TestProvisionUser(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("is idempotent on the provider/subject tuple", func(t *testing.T) {
-		svc, _ := newTestService(t)
+		svc, _, testTenantID := newTestService(t)
 
-		first, created, err := svc.ProvisionUser(ctx, *ownerParams())
+		first, created, err := svc.ProvisionUser(ctx, testTenantID, *ownerParams())
 		if err != nil {
 			t.Fatalf("provision: %v", err)
 		}
@@ -617,7 +633,7 @@ func TestProvisionUser(t *testing.T) {
 			t.Error("first call should report a creation")
 		}
 
-		second, created, err := svc.ProvisionUser(ctx, *ownerParams())
+		second, created, err := svc.ProvisionUser(ctx, testTenantID, *ownerParams())
 		if err != nil {
 			t.Fatalf("provision again: %v", err)
 		}
@@ -630,15 +646,15 @@ func TestProvisionUser(t *testing.T) {
 	})
 
 	t.Run("reconciles profile fields without touching platform roles", func(t *testing.T) {
-		svc, store := newTestService(t)
+		svc, store, testTenantID := newTestService(t)
 
-		user, _, err := svc.ProvisionUser(ctx, *ownerParams())
+		user, _, err := svc.ProvisionUser(ctx, testTenantID, *ownerParams())
 		if err != nil {
 			t.Fatalf("provision: %v", err)
 		}
 
 		active := false
-		if _, _, err := svc.ProvisionUser(ctx, service.UserIdentityParams{
+		if _, _, err := svc.ProvisionUser(ctx, testTenantID, service.UserIdentityParams{
 			Provider:    "openid-connect",
 			Subject:     "sub-owner",
 			DisplayName: strPtr("Renamed"),
@@ -669,23 +685,29 @@ func TestProvisionUser(t *testing.T) {
 		}
 
 		store := xologorm.NewStore(db)
-		svc := service.NewProvisioningService(store, store, store,
+		svc := service.NewProvisioningService(store, store, store, store,
 			service.WithReservedEmails("boss@corp.tld"),
 		)
+
+		tenant, err := store.GetTenantBySlug(ctx, model.DefaultTenantSlug)
+		if err != nil {
+			t.Fatalf("get default tenant: %v", err)
+		}
+		testTenantID := tenant.ID()
 
 		params := *ownerParams()
 		params.Email = strPtr("Boss@Corp.tld")
 
-		if _, _, err := svc.ProvisionUser(ctx, params); !errors.Is(err, port.ErrInvalid) {
+		if _, _, err := svc.ProvisionUser(ctx, testTenantID, params); !errors.Is(err, port.ErrInvalid) {
 			t.Errorf("provision with reserved email: got %v, want port.ErrInvalid", err)
 		}
 
-		user, _, err := svc.ProvisionUser(ctx, *ownerParams())
+		user, _, err := svc.ProvisionUser(ctx, testTenantID, *ownerParams())
 		if err != nil {
 			t.Fatalf("provision: %v", err)
 		}
 
-		if _, err := svc.UpdateUser(ctx, user.ID(), service.UpdateUserParams{
+		if _, err := svc.UpdateUser(ctx, testTenantID, user.ID(), service.UpdateUserParams{
 			Email: strPtr("boss@corp.tld"),
 		}); !errors.Is(err, port.ErrInvalid) {
 			t.Errorf("update with reserved email: got %v, want port.ErrInvalid", err)

--- a/internal/core/service/quota_test.go
+++ b/internal/core/service/quota_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
 	"github.com/xolo-gateway/xolo/internal/core/service"
-	"github.com/pkg/errors"
 )
 
 // ── Fakes ─────────────────────────────────────────────────────────────────────
@@ -77,15 +77,16 @@ type fakeOrg struct {
 	shareQuotaEqually bool
 }
 
-func (o *fakeOrg) ID() model.OrgID         { return "org1" }
-func (o *fakeOrg) Slug() string            { return "org1" }
-func (o *fakeOrg) Name() string            { return "Org1" }
-func (o *fakeOrg) Description() string     { return "" }
-func (o *fakeOrg) Active() bool            { return true }
-func (o *fakeOrg) Currency() string        { return "EUR" }
-func (o *fakeOrg) CreatedAt() time.Time    { return time.Time{} }
-func (o *fakeOrg) UpdatedAt() time.Time    { return time.Time{} }
-func (o *fakeOrg) ShareQuotaEqually() bool { return o.shareQuotaEqually }
+func (o *fakeOrg) ID() model.OrgID          { return "org1" }
+func (o *fakeOrg) TenantID() model.TenantID { return "tenant1" }
+func (o *fakeOrg) Slug() string             { return "org1" }
+func (o *fakeOrg) Name() string             { return "Org1" }
+func (o *fakeOrg) Description() string      { return "" }
+func (o *fakeOrg) Active() bool             { return true }
+func (o *fakeOrg) Currency() string         { return "EUR" }
+func (o *fakeOrg) CreatedAt() time.Time     { return time.Time{} }
+func (o *fakeOrg) UpdatedAt() time.Time     { return time.Time{} }
+func (o *fakeOrg) ShareQuotaEqually() bool  { return o.shareQuotaEqually }
 
 // fakeQuota satisfies model.Quota.
 type fakeQuota struct {

--- a/internal/http/context/tenant.go
+++ b/internal/http/context/tenant.go
@@ -1,0 +1,38 @@
+package context
+
+import (
+	"context"
+
+	"github.com/xolo-gateway/xolo/internal/core/model"
+)
+
+const keyTenant contextKey = "tenant"
+
+// Tenant returns the tenant the request is addressed to. It is always set on a
+// request that reached a handler — the tenant middleware runs before everything
+// else and answers 404 when it can not resolve one — but it returns nil rather
+// than panicking so a handler exercised outside the middleware chain (tests,
+// background tasks) degrades instead of crashing.
+func Tenant(ctx context.Context) model.Tenant {
+	tenant, ok := ctx.Value(keyTenant).(model.Tenant)
+	if !ok {
+		return nil
+	}
+
+	return tenant
+}
+
+// TenantID returns the identifier of the current tenant, or an empty one when
+// no tenant is set. It is the form most stores and filters expect.
+func TenantID(ctx context.Context) model.TenantID {
+	tenant := Tenant(ctx)
+	if tenant == nil {
+		return ""
+	}
+
+	return tenant.ID()
+}
+
+func SetTenant(ctx context.Context, tenant model.Tenant) context.Context {
+	return context.WithValue(ctx, keyTenant, tenant)
+}

--- a/internal/http/handler/api/authz_test.go
+++ b/internal/http/handler/api/authz_test.go
@@ -29,9 +29,12 @@ type fakeOrgStore struct {
 	memberships map[string]model.Membership // key: userID+"/"+orgID
 }
 
-func (s *fakeOrgStore) GetOrgBySlug(ctx context.Context, slug string) (model.Organization, error) {
+func (s *fakeOrgStore) GetOrgBySlug(ctx context.Context, tenantID model.TenantID, slug string) (model.Organization, error) {
 	org, ok := s.orgsBySlug[slug]
 	if !ok {
+		return nil, port.ErrNotFound
+	}
+	if org.TenantID() != tenantID {
 		return nil, port.ErrNotFound
 	}
 	return org, nil
@@ -72,10 +75,10 @@ func (s *fakeVirtualModelStore) DeleteVirtualModel(ctx context.Context, id model
 // belonged to the model's owning org, so any authenticated user could
 // forge a DELETE for a vmID belonging to an org they have no access to.
 func TestHandleDeleteVirtualModel_RejectsCrossOrgRequest(t *testing.T) {
-	orgA := model.NewOrganization("org-a", "Org A", "")
-	orgB := model.NewOrganization("org-b", "Org B", "")
+	orgA := model.NewOrganization(testTenantID, "org-a", "Org A", "")
+	orgB := model.NewOrganization(testTenantID, "org-b", "Org B", "")
 
-	attacker := model.NewUser("test", "attacker", "attacker@example.com", "Attacker", true, "user")
+	attacker := model.NewUser(testTenantID, "test", "attacker", "attacker@example.com", "Attacker", true, "user")
 
 	orgStore := &fakeOrgStore{
 		orgsBySlug: map[string]model.Organization{
@@ -116,3 +119,8 @@ func TestHandleDeleteVirtualModel_RejectsCrossOrgRequest(t *testing.T) {
 }
 
 var _ http.Handler = &api.Handler{}
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/http/handler/api/middlewares.go
+++ b/internal/http/handler/api/middlewares.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
 	"github.com/xolo-gateway/xolo/internal/core/rbac"
 	"github.com/xolo-gateway/xolo/internal/core/secretcleanup"
-	"github.com/pkg/errors"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
 )
 
 // mwResource adapts the middleware store to the generic pipeline graph handlers.
@@ -246,7 +247,7 @@ func (h *Handler) orgForPerm(w http.ResponseWriter, r *http.Request, perm rbac.P
 	ctx := r.Context()
 	orgSlug := r.PathValue("orgSlug")
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)

--- a/internal/http/handler/api/plugin_ui_config.go
+++ b/internal/http/handler/api/plugin_ui_config.go
@@ -33,7 +33,7 @@ func (h *Handler) handleSeedPluginUIConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)
@@ -135,7 +135,7 @@ func (h *Handler) handleReadPluginUIConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)

--- a/internal/http/handler/api/virtual_models.go
+++ b/internal/http/handler/api/virtual_models.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
 	"github.com/xolo-gateway/xolo/internal/core/rbac"
 	"github.com/xolo-gateway/xolo/internal/core/secretcleanup"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
 	proto "github.com/xolo-gateway/xolo/pkg/pluginsdk/proto"
-	"github.com/pkg/errors"
 )
 
 // ─── Request / response shapes ───────────────────────────────────────────────
@@ -67,7 +68,7 @@ func (h *Handler) handleListVirtualModels(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	orgSlug := r.PathValue("orgSlug")
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)
@@ -104,7 +105,7 @@ func (h *Handler) handleCreateVirtualModel(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	orgSlug := r.PathValue("orgSlug")
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)
@@ -320,7 +321,7 @@ func (h *Handler) handleImportVirtualModel(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	orgSlug := r.PathValue("orgSlug")
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "org not found", http.StatusNotFound)
@@ -390,5 +391,3 @@ func sanitizeFilename(name string) string {
 func toVMResponse(vm model.VirtualModel) pipelineEntityResponse {
 	return toEntityResponse(vm.(model.PipelineEntity))
 }
-
-

--- a/internal/http/handler/webui/admin/index_page.go
+++ b/internal/http/handler/webui/admin/index_page.go
@@ -31,7 +31,9 @@ func (h *Handler) getIndexPage(w http.ResponseWriter, r *http.Request) {
 
 	since := time.Now().Add(-overviewWindow)
 
-	orgs, _, err := h.orgStore.ListOrgs(ctx, port.ListOrgsOptions{})
+	tenantID := httpCtx.TenantID(ctx)
+
+	orgs, _, err := h.orgStore.ListOrgs(ctx, port.ListOrgsOptions{TenantID: &tenantID})
 	if err != nil {
 		slog.ErrorContext(ctx, "could not list orgs", slogx.Error(err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/internal/http/handler/webui/admin/orgs.go
+++ b/internal/http/handler/webui/admin/orgs.go
@@ -20,7 +20,11 @@ func (h *Handler) getOrgsPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user := httpCtx.User(ctx)
 
-	orgs, _, err := h.orgStore.ListOrgs(ctx, port.ListOrgsOptions{})
+	// The platform console is tenant-scoped: a platform admin administers its
+	// own tenant, never the whole instance.
+	tenantID := httpCtx.TenantID(ctx)
+
+	orgs, _, err := h.orgStore.ListOrgs(ctx, port.ListOrgsOptions{TenantID: &tenantID})
 	if err != nil {
 		slog.ErrorContext(ctx, "could not list orgs", slogx.Error(err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -135,7 +139,7 @@ func (h *Handler) createOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	org := model.NewOrganization(slug, name, description)
+	org := model.NewOrganization(httpCtx.TenantID(ctx), slug, name, description)
 	if err := h.orgStore.CreateOrg(ctx, org); err != nil {
 		slog.ErrorContext(ctx, "could not create org", slogx.Error(err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/internal/http/handler/webui/admin/users.go
+++ b/internal/http/handler/webui/admin/users.go
@@ -208,11 +208,16 @@ func (h *Handler) fillUsersPageVModelUsers(ctx context.Context, vmodel *componen
 
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 
-	filterOpts := port.QueryUsersOptions{Search: search}
+	// The platform console is tenant-scoped: a platform admin administers the
+	// accounts of its own tenant, never those of the whole instance.
+	tenantID := httpCtx.TenantID(ctx)
+
+	filterOpts := port.QueryUsersOptions{Search: search, TenantID: &tenantID}
 	opts := port.QueryUsersOptions{
-		Page:   &page,
-		Limit:  &limit,
-		Search: search,
+		Page:     &page,
+		Limit:    &limit,
+		Search:   search,
+		TenantID: &tenantID,
 	}
 
 	total, err := h.userStore.CountUsers(ctx, filterOpts)
@@ -228,7 +233,7 @@ func (h *Handler) fillUsersPageVModelUsers(ctx context.Context, vmodel *componen
 	// The subtitle states how many accounts are deactivated. It is a count on the
 	// unfiltered set, so it keeps meaning something while a search is active.
 	inactive := false
-	inactiveCount, err := h.userStore.CountUsers(ctx, port.QueryUsersOptions{Active: &inactive})
+	inactiveCount, err := h.userStore.CountUsers(ctx, port.QueryUsersOptions{Active: &inactive, TenantID: &tenantID})
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/http/handler/webui/common/component/nav_test.go
+++ b/internal/http/handler/webui/common/component/nav_test.go
@@ -59,7 +59,7 @@ func findEntry(groups []NavGroup, label string) (NavEntry, bool) {
 }
 
 func TestPersonalNavGroups(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	ctx := testContext(user, nil, nil)
 
 	groups := PersonalNavGroups(ctx, "tokens")
@@ -89,7 +89,7 @@ func TestPersonalNavGroups(t *testing.T) {
 }
 
 func TestPlatformNavGroups(t *testing.T) {
-	user := model.NewUser("test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
+	user := model.NewUser(testTenantID, "test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
 	ctx := testContext(user, nil, nil)
 
 	groups := PlatformNavGroups(ctx, "users")
@@ -126,7 +126,7 @@ func TestPlatformNavGroups(t *testing.T) {
 }
 
 func TestOrgNavGroupsFiltersOnPermissions(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	orgID := model.OrgID("org-1")
 
 	t.Run("member without any admin permission", func(t *testing.T) {
@@ -179,9 +179,9 @@ func TestOrgNavGroupsFiltersOnPermissions(t *testing.T) {
 }
 
 func TestSwitcherEntriesOrdering(t *testing.T) {
-	user := model.NewUser("test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
-	zebra := model.NewOrganization("zebra", "Zebra", "")
-	acme := model.NewOrganization("acme", "ACME Corp", "")
+	user := model.NewUser(testTenantID, "test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
+	zebra := model.NewOrganization(testTenantID, "zebra", "Zebra", "")
+	acme := model.NewOrganization(testTenantID, "acme", "ACME Corp", "")
 	memberships := []model.Membership{
 		fakeMembership{orgID: zebra.ID(), org: zebra},
 		fakeMembership{orgID: acme.ID(), org: acme},
@@ -209,7 +209,7 @@ func TestSwitcherEntriesOrdering(t *testing.T) {
 }
 
 func TestSwitcherOmitsPlatformForNonAdmins(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 
 	for _, e := range SwitcherEntries(testContext(user, nil, nil), ContextPersonal, "") {
 		if e.Context == ContextPlatform {
@@ -219,7 +219,7 @@ func TestSwitcherOmitsPlatformForNonAdmins(t *testing.T) {
 }
 
 func TestResolveDefaults(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	ctx := testContext(user, nil, nil)
 
 	resolved := AppLayoutVModel{}.resolve(ctx)
@@ -245,9 +245,9 @@ func TestResolveDetectsAdminVisit(t *testing.T) {
 	orgID := model.OrgID("org-1")
 	visited := AppLayoutVModel{Context: ContextOrg, ContextSlug: "acme", ContextOrgID: orgID}
 
-	admin := model.NewUser("test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
-	member := model.NewUser("test", "subject", "user@xolo.test", "Ada", true, authz.RoleUser)
-	membership := []model.Membership{fakeMembership{orgID: orgID, org: model.NewOrganization("acme", "ACME", "")}}
+	admin := model.NewUser(testTenantID, "test", "subject", "admin@xolo.test", "Root", true, authz.RoleAdmin)
+	member := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada", true, authz.RoleUser)
+	membership := []model.Membership{fakeMembership{orgID: orgID, org: model.NewOrganization(testTenantID, "acme", "ACME", "")}}
 
 	if !visited.resolve(testContext(admin, nil, nil)).IsAdminVisit {
 		t.Error("a platform admin browsing an org they do not belong to is an admin visit")
@@ -261,7 +261,7 @@ func TestResolveDetectsAdminVisit(t *testing.T) {
 }
 
 func TestAppLayoutRendersShellAnchors(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	ctx := testContext(user, nil, nil)
 
 	var out strings.Builder
@@ -308,7 +308,7 @@ func TestAppLayoutRendersShellAnchors(t *testing.T) {
 // place, so a script only some pages declare is missing on all the others. Every
 // script a page may need is therefore registered by the layout itself.
 func TestAppLayoutShipsComponentScripts(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	ctx := testContext(user, nil, nil)
 
 	var out strings.Builder
@@ -396,3 +396,8 @@ func TestSwitcherGroupLabel(t *testing.T) {
 		}
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/http/handler/webui/landing_test.go
+++ b/internal/http/handler/webui/landing_test.go
@@ -17,8 +17,8 @@ func TestLandingWithoutOrg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	admin := model.NewUser("test", "s1", "admin@xolo.test", "Admin", true, authz.RoleAdmin)
-	plain := model.NewUser("test", "s2", "user@xolo.test", "User", true, authz.RoleUser)
+	admin := model.NewUser(testTenantID, "test", "s1", "admin@xolo.test", "Admin", true, authz.RoleAdmin)
+	plain := model.NewUser(testTenantID, "test", "s2", "user@xolo.test", "User", true, authz.RoleUser)
 
 	if got, want := landingWithoutOrg(admin, base), "http://xolo.test/admin/"; got != want {
 		t.Errorf("administrator: got %q, want %q", got, want)
@@ -30,3 +30,8 @@ func TestLandingWithoutOrg(t *testing.T) {
 		t.Errorf("anonymous: got %q, want %q", got, want)
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/http/handler/webui/org/applications.go
+++ b/internal/http/handler/webui/org/applications.go
@@ -24,7 +24,7 @@ func (h *Handler) getApplicationsPage(w http.ResponseWriter, r *http.Request) {
 	orgSlug := r.PathValue("orgSlug")
 	user := httpCtx.User(ctx)
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "Organization not found", http.StatusNotFound)
@@ -93,7 +93,7 @@ func (h *Handler) getNewApplicationPage(w http.ResponseWriter, r *http.Request) 
 	orgSlug := r.PathValue("orgSlug")
 	user := httpCtx.User(ctx)
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "Organization not found", http.StatusNotFound)
@@ -159,7 +159,7 @@ func (h *Handler) createApplication(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "Organization not found", http.StatusNotFound)
@@ -223,7 +223,7 @@ func (h *Handler) getEditApplicationPage(w http.ResponseWriter, r *http.Request)
 	appID := r.PathValue("appID")
 	user := httpCtx.User(ctx)
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "Organization not found", http.StatusNotFound)
@@ -388,7 +388,7 @@ func (h *Handler) createApplicationToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 	if err != nil {
 		if errors.Is(err, port.ErrNotFound) {
 			http.Error(w, "Organization not found", http.StatusNotFound)

--- a/internal/http/handler/webui/org/authz.go
+++ b/internal/http/handler/webui/org/authz.go
@@ -27,7 +27,7 @@ func (h *Handler) hasPermission(orgSlug string, perm rbac.Permission) authz.Asse
 			return true, nil
 		}
 
-		org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+		org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 		if err != nil {
 			return false, errors.WithStack(err)
 		}
@@ -52,7 +52,7 @@ func (h *Handler) hasAnyPermission(orgSlug string, perms ...rbac.Permission) aut
 			return true, nil
 		}
 
-		org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+		org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 		if err != nil {
 			return false, errors.WithStack(err)
 		}
@@ -95,7 +95,7 @@ func (h *Handler) hasOrgMembership(orgSlug string) authz.AssertFunc {
 			return true, nil
 		}
 
-		org, err := h.orgStore.GetOrgBySlug(ctx, orgSlug)
+		org, err := h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 		if err != nil {
 			return false, errors.WithStack(err)
 		}
@@ -119,7 +119,7 @@ func (h *Handler) hasOrgMembership(orgSlug string) authz.AssertFunc {
 
 // orgFromSlug resolves the org from the request path slug.
 func (h *Handler) orgFromSlug(ctx context.Context, orgSlug string) (model.Organization, error) {
-	return h.orgStore.GetOrgBySlug(ctx, orgSlug)
+	return h.orgStore.GetOrgBySlug(ctx, httpCtx.TenantID(ctx), orgSlug)
 }
 
 // currentUser retrieves the current user from context.

--- a/internal/http/handler/webui/profile/component/dashboard_page_test.go
+++ b/internal/http/handler/webui/profile/component/dashboard_page_test.go
@@ -15,7 +15,7 @@ import (
 // reading as a dashboard, and a missing figure becomes indistinguishable from a
 // failed load. Every frame is rendered on a brand new account too.
 func TestDashboardPageKeepsEveryBlockWhenEmpty(t *testing.T) {
-	user := model.NewUser("test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "test", "subject", "user@xolo.test", "Ada Lovelace", true, authz.RoleUser)
 	ctx := httpCtx.SetBaseURL(context.Background(), "http://xolo.test")
 	ctx = httpCtx.SetUser(ctx, user)
 	ctx = httpCtx.SetMemberships(ctx, nil)
@@ -41,3 +41,8 @@ func TestDashboardPageKeepsEveryBlockWhenEmpty(t *testing.T) {
 		}
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/http/middleware/authn/middleware.go
+++ b/internal/http/middleware/authn/middleware.go
@@ -5,9 +5,10 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/pkg/errors"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
 	"github.com/xolo-gateway/xolo/internal/http/handler/webui/common"
 	"github.com/xolo-gateway/xolo/internal/metrics"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -39,6 +40,19 @@ func Middleware(onUnauthorized func(w http.ResponseWriter, r *http.Request), aut
 				}
 
 				ctx := r.Context()
+
+				// An identity stamped with another tenant is treated as if the
+				// authenticator had found nothing: a session cookie set on a
+				// parent domain, or an API token issued elsewhere, must never
+				// authenticate on this tenant. Checked once here rather than in
+				// every authenticator, so a new one can not forget it.
+				if tenant := httpCtx.Tenant(ctx); tenant != nil && user.TenantID != "" && user.TenantID != string(tenant.ID()) {
+					slog.WarnContext(ctx, "rejecting identity authenticated on another tenant",
+						slog.String("identityTenantID", user.TenantID),
+						slog.String("requestTenantID", string(tenant.ID())))
+					continue
+				}
+
 				ctx = SetContextUser(ctx, user)
 
 				r = r.WithContext(ctx)

--- a/internal/http/middleware/authn/oidc/session.go
+++ b/internal/http/middleware/authn/oidc/session.go
@@ -5,9 +5,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/xolo-gateway/xolo/internal/http/middleware/authn"
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
+	"github.com/xolo-gateway/xolo/internal/http/middleware/authn"
 )
 
 const userAttr = "u"
@@ -22,6 +23,12 @@ func (h *Handler) storeSessionUser(w http.ResponseWriter, r *http.Request, user 
 	sess, err := h.getSession(r)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	// Stamp the tenant the session was opened on, so it can not be replayed on
+	// another one (see authn.Middleware).
+	if tenant := httpCtx.Tenant(r.Context()); tenant != nil {
+		user.TenantID = string(tenant.ID())
 	}
 
 	sess.Values[userAttr] = user

--- a/internal/http/middleware/authn/token/handler.go
+++ b/internal/http/middleware/authn/token/handler.go
@@ -12,6 +12,10 @@ type Handler struct {
 	sessionStore sessions.Store
 	sessionName  string
 	userStore    port.UserStore
+	// orgStore resolves the tenant owning the organization an application token
+	// is scoped to. A user token carries its tenant through its owner; an
+	// application token only knows its organization.
+	orgStore port.OrgStore
 }
 
 // ServeHTTP implements [http.Handler].
@@ -19,13 +23,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mux.ServeHTTP(w, r)
 }
 
-func NewHandler(sessionStore sessions.Store, userStore port.UserStore, funcs ...OptionFunc) *Handler {
+func NewHandler(sessionStore sessions.Store, userStore port.UserStore, orgStore port.OrgStore, funcs ...OptionFunc) *Handler {
 	opts := NewOptions(funcs...)
 	h := &Handler{
 		mux:          http.NewServeMux(),
 		sessionStore: sessionStore,
 		sessionName:  opts.SessionName,
 		userStore:    userStore,
+		orgStore:     orgStore,
 	}
 
 	h.mux.HandleFunc("GET /login", h.getLoginPage)

--- a/internal/http/middleware/authn/token/login.go
+++ b/internal/http/middleware/authn/token/login.go
@@ -76,6 +76,12 @@ func (h *Handler) getUserFromToken(ctx context.Context, token string) (*authn.Us
 		if !app.Active() {
 			return nil, errors.WithStack(port.ErrNotFound)
 		}
+
+		org, err := h.orgStore.GetOrgByID(ctx, authToken.OrgID())
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
 		// Provider/Subject are what permission resolution keys off to map the
 		// request back to the application and its org roles — see
 		// memberships.newPermissionResolver.
@@ -85,6 +91,7 @@ func (h *Handler) getUserFromToken(ctx context.Context, token string) (*authn.Us
 			DisplayName: app.Name(),
 			OrgID:       string(authToken.OrgID()),
 			TokenID:     string(authToken.ID()),
+			TenantID:    string(org.TenantID()),
 		}, nil
 	}
 
@@ -111,5 +118,6 @@ func (h *Handler) getUserFromToken(ctx context.Context, token string) (*authn.Us
 		DisplayName: user.DisplayName(),
 		OrgID:       string(authToken.OrgID()),
 		TokenID:     string(authToken.ID()),
+		TenantID:    string(user.TenantID()),
 	}, nil
 }

--- a/internal/http/middleware/authn/token/session.go
+++ b/internal/http/middleware/authn/token/session.go
@@ -5,9 +5,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/xolo-gateway/xolo/internal/http/middleware/authn"
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
+	"github.com/xolo-gateway/xolo/internal/http/middleware/authn"
 )
 
 const userAttr = "u"
@@ -22,6 +23,12 @@ func (h *Handler) storeSessionUser(w http.ResponseWriter, r *http.Request, user 
 	sess, err := h.getSession(r)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	// Stamp the tenant the session was opened on, so it can not be replayed on
+	// another one (see authn.Middleware).
+	if tenant := httpCtx.Tenant(r.Context()); tenant != nil {
+		user.TenantID = string(tenant.ID())
 	}
 
 	sess.Values[userAttr] = user

--- a/internal/http/middleware/authn/user.go
+++ b/internal/http/middleware/authn/user.go
@@ -7,4 +7,10 @@ type User struct {
 	DisplayName string
 	OrgID       string
 	TokenID     string
+
+	// TenantID is the tenant the identity was authenticated on. It is stamped
+	// on the session so a cookie set on a parent domain can not carry an
+	// identity from one tenant to another: an authenticator that finds a
+	// mismatch treats the session as absent.
+	TenantID string
 }

--- a/internal/http/middleware/bridge/middleware.go
+++ b/internal/http/middleware/bridge/middleware.go
@@ -56,9 +56,17 @@ func Middleware(userStore port.UserStore, emitter port.EventEmitter, opts Option
 				return
 			}
 
+			// The tenant middleware runs before this one and answers 404 when it
+			// resolves none, so a request reaching here always carries one.
+			tenant := httpCtx.Tenant(ctx)
+			if tenant == nil {
+				common.HandleError(w, r, common.NewHTTPError(http.StatusNotFound))
+				return
+			}
+
 			isDefaultAdmin := slices.Contains(opts.DefaultAdmins, authnUser.Email)
 
-			user, err := userStore.GetUserByIdentity(ctx, authnUser.Provider, authnUser.Subject)
+			user, err := userStore.GetUserByIdentity(ctx, tenant.ID(), authnUser.Provider, authnUser.Subject)
 			if err != nil {
 				if !errors.Is(err, port.ErrNotFound) {
 					common.HandleError(w, r, err)
@@ -79,6 +87,7 @@ func Middleware(userStore port.UserStore, emitter port.EventEmitter, opts Option
 				}
 
 				user = model.NewUser(
+					tenant.ID(),
 					authnUser.Provider, authnUser.Subject, authnUser.Email, authnUser.DisplayName,
 					opts.ActiveByDefault || isDefaultAdmin,
 					authz.RoleUser,

--- a/internal/http/middleware/bridge/middleware_test.go
+++ b/internal/http/middleware/bridge/middleware_test.go
@@ -78,6 +78,9 @@ func call(t *testing.T, store port.UserStore, opts bridge.Options, identity *aut
 	reqCtx := authn.SetContextUser(req.Context(), identity)
 	reqCtx = httpCtx.SetBaseURL(reqCtx, "/")
 	reqCtx = httpCtx.SetCurrentURL(reqCtx, req.URL)
+	// The tenant middleware runs before the bridge in the real chain: without a
+	// tenant the bridge has no scope to resolve the identity in.
+	reqCtx = httpCtx.SetTenant(reqCtx, testTenant)
 
 	req = req.WithContext(reqCtx)
 
@@ -111,7 +114,7 @@ func TestAutoCreateEnabled(t *testing.T) {
 			t.Fatalf("request should have been served, got status %d", result.status)
 		}
 
-		user, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-1")
+		user, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-1")
 		if err != nil {
 			t.Fatalf("get user: %v", err)
 		}
@@ -137,7 +140,7 @@ func TestAutoCreateEnabled(t *testing.T) {
 			t.Fatalf("request should have been served, got status %d", result.status)
 		}
 
-		user, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-1")
+		user, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-1")
 		if err != nil {
 			t.Fatalf("get user: %v", err)
 		}
@@ -163,7 +166,7 @@ func TestAutoCreateDisabled(t *testing.T) {
 		if result.status != http.StatusForbidden {
 			t.Errorf("status: got %d, want %d", result.status, http.StatusForbidden)
 		}
-		if _, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-1"); !errors.Is(err, port.ErrNotFound) {
+		if _, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-1"); !errors.Is(err, port.ErrNotFound) {
 			t.Errorf("no user should have been created, got %v", err)
 		}
 		if types := result.emitter.types(); !slices.Contains(types, model.EventTypeAuthLoginFailed) {
@@ -174,7 +177,7 @@ func TestAutoCreateDisabled(t *testing.T) {
 	t.Run("accepts a pre-provisioned identity", func(t *testing.T) {
 		store := newStore(t)
 
-		provisioned := model.NewUser("openid-connect", "sub-1", "jean@corp.tld", "Jean", true, model.PlatformRoleUser)
+		provisioned := model.NewUser(testTenantID, "openid-connect", "sub-1", "jean@corp.tld", "Jean", true, model.PlatformRoleUser)
 		if err := store.SaveUser(ctx, provisioned); err != nil {
 			t.Fatalf("save user: %v", err)
 		}
@@ -204,7 +207,7 @@ func TestAutoCreateDisabled(t *testing.T) {
 			t.Fatalf("request should have been served, got status %d", result.status)
 		}
 
-		user, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-boss")
+		user, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-boss")
 		if err != nil {
 			t.Fatalf("get user: %v", err)
 		}
@@ -223,7 +226,7 @@ func TestExistingUserSynchronization(t *testing.T) {
 	t.Run("updates the profile from the identity provider", func(t *testing.T) {
 		store := newStore(t)
 
-		existing := model.NewUser("openid-connect", "sub-1", "old@corp.tld", "Old", true, model.PlatformRoleUser)
+		existing := model.NewUser(testTenantID, "openid-connect", "sub-1", "old@corp.tld", "Old", true, model.PlatformRoleUser)
 		if err := store.SaveUser(ctx, existing); err != nil {
 			t.Fatalf("save user: %v", err)
 		}
@@ -231,7 +234,7 @@ func TestExistingUserSynchronization(t *testing.T) {
 		call(t, store, bridge.Options{AutoCreateUsers: true, ActiveByDefault: true},
 			newIdentity("sub-1", "new@corp.tld", "New"))
 
-		user, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-1")
+		user, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-1")
 		if err != nil {
 			t.Fatalf("get user: %v", err)
 		}
@@ -245,7 +248,7 @@ func TestExistingUserSynchronization(t *testing.T) {
 	t.Run("keeps stored values when the identity carries none", func(t *testing.T) {
 		store := newStore(t)
 
-		existing := model.NewUser("openid-connect", "sub-1", "jean@corp.tld", "Jean", true, model.PlatformRoleUser)
+		existing := model.NewUser(testTenantID, "openid-connect", "sub-1", "jean@corp.tld", "Jean", true, model.PlatformRoleUser)
 		if err := store.SaveUser(ctx, existing); err != nil {
 			t.Fatalf("save user: %v", err)
 		}
@@ -253,7 +256,7 @@ func TestExistingUserSynchronization(t *testing.T) {
 		call(t, store, bridge.Options{AutoCreateUsers: true, ActiveByDefault: true},
 			newIdentity("sub-1", "", ""))
 
-		user, err := store.GetUserByIdentity(ctx, "openid-connect", "sub-1")
+		user, err := store.GetUserByIdentity(ctx, testTenantID, "openid-connect", "sub-1")
 		if err != nil {
 			t.Fatalf("get user: %v", err)
 		}
@@ -262,3 +265,20 @@ func TestExistingUserSynchronization(t *testing.T) {
 		}
 	})
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")
+
+// testTenant is what the tenant middleware would have injected in the request
+// context. Only its identifier matters here: the bridge scopes the identity
+// lookup with it and never reads the tenant back from the store.
+var testTenant = &stubTenant{id: testTenantID}
+
+type stubTenant struct {
+	model.Tenant
+	id model.TenantID
+}
+
+func (t *stubTenant) ID() model.TenantID { return t.id }

--- a/internal/http/middleware/memberships/middleware_test.go
+++ b/internal/http/middleware/memberships/middleware_test.go
@@ -38,7 +38,7 @@ func TestPermissionResolver_Application(t *testing.T) {
 	store := &stubRoleStore{}
 	// The shadow user backing an application: provider "application", subject
 	// carrying the ApplicationID.
-	user := model.NewUser(model.ApplicationProvider, "app-123", "", "CI", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, model.ApplicationProvider, "app-123", "", "CI", true, authz.RoleUser)
 
 	resolve := newPermissionResolver(store, user)
 
@@ -73,7 +73,7 @@ func TestPermissionResolver_Application(t *testing.T) {
 // created by the authn bridge, not granted by an operator.
 func TestPermissionResolver_ApplicationNeverGlobalAdmin(t *testing.T) {
 	store := &stubRoleStore{}
-	user := model.NewUser(model.ApplicationProvider, "app-123", "", "CI", true, authz.RoleAdmin)
+	user := model.NewUser(testTenantID, model.ApplicationProvider, "app-123", "", "CI", true, authz.RoleAdmin)
 
 	set, err := newPermissionResolver(store, user)(context.Background(), "org-1")
 	if err != nil {
@@ -90,7 +90,7 @@ func TestPermissionResolver_ApplicationNeverGlobalAdmin(t *testing.T) {
 
 func TestPermissionResolver_User(t *testing.T) {
 	store := &stubRoleStore{}
-	user := model.NewUser("oidc", "u1", "u1@example.com", "U1", true, authz.RoleUser)
+	user := model.NewUser(testTenantID, "oidc", "u1", "u1@example.com", "U1", true, authz.RoleUser)
 
 	set, err := newPermissionResolver(store, user)(context.Background(), "org-1")
 	if err != nil {
@@ -110,7 +110,7 @@ func TestPermissionResolver_User(t *testing.T) {
 
 func TestPermissionResolver_GlobalAdmin(t *testing.T) {
 	store := &stubRoleStore{}
-	user := model.NewUser("oidc", "u1", "u1@example.com", "U1", true, authz.RoleUser, authz.RoleAdmin)
+	user := model.NewUser(testTenantID, "oidc", "u1", "u1@example.com", "U1", true, authz.RoleUser, authz.RoleAdmin)
 
 	set, err := newPermissionResolver(store, user)(context.Background(), "org-1")
 	if err != nil {
@@ -124,3 +124,8 @@ func TestPermissionResolver_GlobalAdmin(t *testing.T) {
 		t.Error("a global admin should not hit the role store")
 	}
 }
+
+// testTenantID is the tenant every fixture of this package belongs to.
+// Tenancy is not what these tests exercise: they only need a stable, shared
+// owner so the tenant-scoped unique keys behave like the pre-tenant ones.
+const testTenantID = model.TenantID("test-tenant")

--- a/internal/http/middleware/tenant/middleware.go
+++ b/internal/http/middleware/tenant/middleware.go
@@ -1,0 +1,171 @@
+// Package tenant resolves the tenant a request is addressed to and injects it
+// in the request context.
+//
+// It is the outermost middleware of the HTTP chain: authentication resolves a
+// user within a tenant, so the tenant must be known before anything else runs.
+package tenant
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/bornholm/go-x/slogx"
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/config"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
+)
+
+// Resolver turns a request into a tenant.
+type Resolver struct {
+	store port.TenantStore
+
+	// hostPrefix and hostSuffix frame the tenant slug inside the host. They are
+	// derived once from the configured pattern: matching a host is then a
+	// prefix/suffix test, with no regexp to compile per request.
+	hostPrefix string
+	hostSuffix string
+
+	defaultSlug string
+	multiTenant bool
+
+	// defaultTenant memoizes the single-tenant resolution: it never varies
+	// across requests, so it is worth not hitting the store on every one. Only
+	// a success is memoized — a transient store failure on the first request
+	// must not disable the instance for the lifetime of the process.
+	defaultMutex  sync.RWMutex
+	defaultTenant model.Tenant
+}
+
+func NewResolver(store port.TenantStore, conf config.Multitenancy) *Resolver {
+	prefix, suffix, _ := strings.Cut(stripPort(conf.HostPattern), config.TenantHostPlaceholder)
+
+	return &Resolver{
+		store:       store,
+		hostPrefix:  strings.ToLower(prefix),
+		hostSuffix:  strings.ToLower(suffix),
+		defaultSlug: conf.DefaultTenantSlug,
+		multiTenant: conf.Enabled,
+	}
+}
+
+// ErrNoTenant reports a request no tenant can be resolved for. It is answered
+// with a 404: on a multi-tenant deployment, an unknown host must not reveal
+// whether the instance exists at all.
+var ErrNoTenant = errors.New("no tenant matches this request")
+
+// Resolve returns the tenant addressed by the request.
+func (r *Resolver) Resolve(ctx context.Context, host string) (model.Tenant, error) {
+	if !r.multiTenant {
+		return r.resolveDefault(ctx)
+	}
+
+	slug, ok := r.slugFromHost(host)
+	if !ok {
+		return nil, errors.WithStack(ErrNoTenant)
+	}
+
+	tenant, err := r.store.GetTenantBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, port.ErrNotFound) {
+			return nil, errors.WithStack(ErrNoTenant)
+		}
+		return nil, errors.WithStack(err)
+	}
+
+	// A deactivated tenant is indistinguishable from an unknown one: suspending
+	// a customer must not leave its login page reachable.
+	if !tenant.Active() {
+		return nil, errors.WithStack(ErrNoTenant)
+	}
+
+	return tenant, nil
+}
+
+// slugFromHost extracts the tenant slug framed by the configured pattern.
+func (r *Resolver) slugFromHost(host string) (string, bool) {
+	host = strings.ToLower(stripPort(host))
+
+	if len(host) <= len(r.hostPrefix)+len(r.hostSuffix) {
+		return "", false
+	}
+	if !strings.HasPrefix(host, r.hostPrefix) || !strings.HasSuffix(host, r.hostSuffix) {
+		return "", false
+	}
+
+	slug := host[len(r.hostPrefix) : len(host)-len(r.hostSuffix)]
+
+	// A subdomain label is a DNS label, which is exactly what a slug is: a host
+	// carrying anything else can not designate a tenant, and rejecting it here
+	// keeps the value out of the store query.
+	if !model.IsValidSlug(slug) {
+		return "", false
+	}
+
+	return slug, true
+}
+
+// resolveDefault returns the tenant every request lands on when multi-tenancy
+// is disabled.
+func (r *Resolver) resolveDefault(ctx context.Context) (model.Tenant, error) {
+	r.defaultMutex.RLock()
+	cached := r.defaultTenant
+	r.defaultMutex.RUnlock()
+
+	if cached != nil {
+		return cached, nil
+	}
+
+	tenant, err := r.store.GetTenantBySlug(ctx, r.defaultSlug)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	r.defaultMutex.Lock()
+	r.defaultTenant = tenant
+	r.defaultMutex.Unlock()
+
+	return tenant, nil
+}
+
+// stripPort removes the ":port" suffix of a host, if any. It tolerates a host
+// with no port, which net.SplitHostPort reports as an error.
+func stripPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+// Middleware injects the resolved tenant in the request context. notFound
+// serves the requests no tenant could be resolved for, so the web UI and the
+// API each answer in their own format.
+func Middleware(resolver *Resolver, notFound http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			tenant, err := resolver.Resolve(ctx, r.Host)
+			if err != nil {
+				if errors.Is(err, ErrNoTenant) {
+					notFound.ServeHTTP(w, r)
+					return
+				}
+
+				slog.ErrorContext(ctx, "could not resolve tenant",
+					slog.String("host", r.Host), slogx.Error(errors.WithStack(err)))
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			ctx = httpCtx.SetTenant(ctx, tenant)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/http/middleware/tenant/middleware_test.go
+++ b/internal/http/middleware/tenant/middleware_test.go
@@ -1,0 +1,166 @@
+package tenant_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/config"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+	httpCtx "github.com/xolo-gateway/xolo/internal/http/context"
+	"github.com/xolo-gateway/xolo/internal/http/middleware/tenant"
+)
+
+// stubTenantStore serves the tenants declared by a test, by slug.
+type stubTenantStore struct {
+	port.TenantStore
+	bySlug map[string]model.Tenant
+	calls  int
+}
+
+func (s *stubTenantStore) GetTenantBySlug(_ context.Context, slug string) (model.Tenant, error) {
+	s.calls++
+
+	tenant, ok := s.bySlug[slug]
+	if !ok {
+		return nil, errors.WithStack(port.ErrNotFound)
+	}
+
+	return tenant, nil
+}
+
+func newStore(tenants ...model.Tenant) *stubTenantStore {
+	bySlug := make(map[string]model.Tenant, len(tenants))
+	for _, tenant := range tenants {
+		bySlug[tenant.Slug()] = tenant
+	}
+	return &stubTenantStore{bySlug: bySlug}
+}
+
+// serve runs the middleware for a host and reports the resolved tenant.
+func serve(t *testing.T, resolver *tenant.Resolver, host string) (status int, resolved model.Tenant) {
+	t.Helper()
+
+	terminal := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resolved = httpCtx.Tenant(r.Context())
+	})
+
+	notFound := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = host
+
+	rec := httptest.NewRecorder()
+	tenant.Middleware(resolver, notFound)(terminal).ServeHTTP(rec, req)
+
+	return rec.Code, resolved
+}
+
+func TestSingleTenant(t *testing.T) {
+	conf := config.Multitenancy{Enabled: false, DefaultTenantSlug: model.DefaultTenantSlug}
+
+	t.Run("serves the default tenant whatever the host", func(t *testing.T) {
+		store := newStore(model.NewTenant(model.DefaultTenantSlug, "Default", ""))
+		resolver := tenant.NewResolver(store, conf)
+
+		for _, host := range []string{"xolo.example.com", "localhost:3002", "10.0.0.1", "anything.at.all"} {
+			status, resolved := serve(t, resolver, host)
+
+			if status != http.StatusOK {
+				t.Errorf("host %q: status got %d, want %d", host, status, http.StatusOK)
+			}
+			if resolved == nil || resolved.Slug() != model.DefaultTenantSlug {
+				t.Errorf("host %q: resolved %v, want the default tenant", host, resolved)
+			}
+		}
+	})
+
+	t.Run("resolves the default tenant only once", func(t *testing.T) {
+		store := newStore(model.NewTenant(model.DefaultTenantSlug, "Default", ""))
+		resolver := tenant.NewResolver(store, conf)
+
+		for range 3 {
+			serve(t, resolver, "xolo.example.com")
+		}
+
+		if store.calls != 1 {
+			t.Errorf("store calls: got %d, want 1 (the resolution is memoized)", store.calls)
+		}
+	})
+
+	t.Run("a store failure is not memoized", func(t *testing.T) {
+		// No default tenant: every request must retry rather than latch the
+		// failure for the lifetime of the process.
+		store := newStore()
+		resolver := tenant.NewResolver(store, conf)
+
+		for range 3 {
+			if status, _ := serve(t, resolver, "xolo.example.com"); status != http.StatusInternalServerError {
+				t.Fatalf("status: got %d, want %d", status, http.StatusInternalServerError)
+			}
+		}
+
+		if store.calls != 3 {
+			t.Errorf("store calls: got %d, want 3", store.calls)
+		}
+	})
+}
+
+func TestMultiTenant(t *testing.T) {
+	conf := config.Multitenancy{
+		Enabled:           true,
+		HostPattern:       "{tenant}.xolo.example.com",
+		DefaultTenantSlug: model.DefaultTenantSlug,
+	}
+
+	suspended := model.UpdateTenant(model.NewTenant("suspended", "Suspended", ""), model.WithTenantActive(false))
+
+	store := newStore(
+		model.NewTenant("acme", "Acme", ""),
+		model.NewTenant(model.DefaultTenantSlug, "Default", ""),
+		suspended,
+	)
+	resolver := tenant.NewResolver(store, conf)
+
+	for name, testCase := range map[string]struct {
+		host       string
+		wantStatus int
+		wantSlug   string
+	}{
+		"known subdomain":              {"acme.xolo.example.com", http.StatusOK, "acme"},
+		"known subdomain with port":    {"acme.xolo.example.com:3002", http.StatusOK, "acme"},
+		"uppercase host":               {"ACME.Xolo.Example.Com", http.StatusOK, "acme"},
+		"default tenant is no special": {"default.xolo.example.com", http.StatusOK, model.DefaultTenantSlug},
+		"unknown subdomain":            {"nope.xolo.example.com", http.StatusNotFound, ""},
+		"deactivated tenant":           {"suspended.xolo.example.com", http.StatusNotFound, ""},
+		"bare domain":                  {"xolo.example.com", http.StatusNotFound, ""},
+		"foreign domain":               {"acme.example.org", http.StatusNotFound, ""},
+		"deeper subdomain":             {"a.b.xolo.example.com", http.StatusNotFound, ""},
+		"empty label":                  {".xolo.example.com", http.StatusNotFound, ""},
+		"bare ip":                      {"10.0.0.1", http.StatusNotFound, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			status, resolved := serve(t, resolver, testCase.host)
+
+			if status != testCase.wantStatus {
+				t.Fatalf("status: got %d, want %d", status, testCase.wantStatus)
+			}
+
+			if testCase.wantSlug == "" {
+				if resolved != nil {
+					t.Errorf("no tenant should have been injected, got %q", resolved.Slug())
+				}
+				return
+			}
+
+			if resolved == nil || resolved.Slug() != testCase.wantSlug {
+				t.Errorf("resolved: got %v, want %q", resolved, testCase.wantSlug)
+			}
+		})
+	}
+}

--- a/internal/http/options.go
+++ b/internal/http/options.go
@@ -12,6 +12,11 @@ type Options struct {
 	Mounts  map[string]http.Handler
 	Routes  map[string]http.Handler
 	CORS    cors.Options
+
+	// Middlewares wrap the whole mux, outside every mount. The first one is the
+	// outermost. Tenant resolution lives here: authentication resolves a user
+	// within a tenant, so the tenant has to be known before any route runs.
+	Middlewares []func(http.Handler) http.Handler
 }
 
 type OptionFunc func(opts *Options)
@@ -58,6 +63,14 @@ func WithBaseURL(baseURL string) OptionFunc {
 func WithAddress(addr string) OptionFunc {
 	return func(opts *Options) {
 		opts.Address = addr
+	}
+}
+
+// WithMiddleware appends a middleware wrapping the entire server, outside every
+// mount and route. They apply in declaration order, the first being outermost.
+func WithMiddleware(middlewares ...func(http.Handler) http.Handler) OptionFunc {
+	return func(opts *Options) {
+		opts.Middlewares = append(opts.Middlewares, middlewares...)
 	}
 }
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -32,6 +32,15 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	handler := sloghttp.Recovery(mux)
+
+	// Applied in reverse so the first declared middleware ends up outermost.
+	// They sit inside the request-scoped context injection below: tenant
+	// resolution renders an error page when it fails, and those templates read
+	// the base and current URLs.
+	for i := len(s.opts.Middlewares) - 1; i >= 0; i-- {
+		handler = s.opts.Middlewares[i](handler)
+	}
+
 	handler = sloghttp.New(slog.Default())(handler)
 	handler = httpmetrics.Middleware()(handler)
 

--- a/internal/provisionning/README.md
+++ b/internal/provisionning/README.md
@@ -15,8 +15,11 @@ Xolo process
 └── provisionning.Server (internal/provisionning)  dedicated listener + port + mutual TLS
         └── handler/v1                   transport only
                 └── service.ProvisioningService   (internal/core/service)
-                        └── port.OrgStore / UserStore / RoleStore
+                        └── port.TenantStore / OrgStore / UserStore / RoleStore
 ```
+
+The resources are nested the way the domain is: a **tenant** owns
+**organizations** and **users**, an organization owns **members** and **roles**.
 
 Both servers share the root context of `cmd/server`, and the Provisionning API uses the
 **same store instances** as the public server (cache and event decorators
@@ -54,34 +57,58 @@ first-request failure.
 | `XOLO_PROVISIONNING_API_TLS_CLIENT_CA_FILE` | — | Authority verifying client certificates, required when enabled |
 | `XOLO_PROVISIONNING_API_SHUTDOWN_TIMEOUT` | `10s` | Graceful shutdown budget |
 
-## Endpoints
+Multi-tenancy is configured on the instance, not on this API:
 
-The external vocabulary is `tenant`; the implementation is `model.Organization`.
-No `Tenant` business object exists.
+| Variable | Default | Description |
+|---|---|---|
+| `XOLO_MULTITENANCY_ENABLED` | `false` | Allows more than one tenant |
+| `XOLO_MULTITENANCY_HOST_PATTERN` | — | Hostname template, e.g. `{tenant}.xolo.example.com`, required when enabled |
+| `XOLO_MULTITENANCY_DEFAULT_TENANT_SLUG` | `default` | The tenant served when multi-tenancy is disabled |
+
+## Endpoints
 
 | Method | Route | Notes |
 |---|---|---|
 | `GET` | `/v1/healthz` | Behind mutual TLS as well |
 | `GET` | `/v1/permissions` | The RBAC catalog: the only source of valid permission codes |
 | `GET` | `/v1/tenants` | `?slug=` for an exact lookup, otherwise `?page=&limit=` |
-| `POST` | `/v1/tenants` | Creates the tenant, its builtin roles and, optionally, its initial owner |
+| `POST` | `/v1/tenants` | **Refused with `409` on a single-tenant instance** |
 | `GET` | `/v1/tenants/{tenantID}` | |
-| `PATCH` | `/v1/tenants/{tenantID}` | `name`, `description`, `active`, `currency`, `shareQuotaEqually`. The slug is immutable |
-| `DELETE` | `/v1/tenants/{tenantID}` | |
-| `GET` | `/v1/tenants/{tenantID}/members` | Paginated |
-| `POST` | `/v1/tenants/{tenantID}/members` | `userId` **or** `user{provider,subject,…}`, plus `roleIds[]` and/or `builtinRoles[]` |
-| `GET` | `/v1/tenants/{tenantID}/members/{membershipID}` | |
-| `PUT` | `/v1/tenants/{tenantID}/members/{membershipID}/roles` | Full replacement of the role set |
-| `DELETE` | `/v1/tenants/{tenantID}/members/{membershipID}` | |
-| `GET` | `/v1/tenants/{tenantID}/roles` | Builtin and custom roles |
-| `POST` | `/v1/tenants/{tenantID}/roles` | Custom role |
-| `GET` | `/v1/tenants/{tenantID}/roles/{roleID}` | |
-| `PUT` | `/v1/tenants/{tenantID}/roles/{roleID}` | Custom roles only |
-| `DELETE` | `/v1/tenants/{tenantID}/roles/{roleID}` | Custom roles only |
-| `GET` | `/v1/users` | `?provider=&subject=` for an exact lookup, otherwise `?search=&active=&page=&limit=` |
-| `PUT` | `/v1/users` | Idempotent upsert on `(provider, subject)`: `201` when created, `200` otherwise |
-| `GET` | `/v1/users/{userID}` | |
-| `PATCH` | `/v1/users/{userID}` | `email`, `displayName`, `active` |
+| `PATCH` | `/v1/tenants/{tenantID}` | `name`, `description`, `active`. The slug is immutable |
+| `DELETE` | `/v1/tenants/{tenantID}` | Removes everything the tenant owns |
+| `GET` | `/v1/tenants/{tenantID}/organizations` | `?slug=` for an exact lookup, otherwise `?page=&limit=` |
+| `POST` | `/v1/tenants/{tenantID}/organizations` | Creates the organization, its builtin roles and, optionally, its initial owner |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}` | |
+| `PATCH` | `/v1/tenants/{tenantID}/organizations/{orgID}` | `name`, `description`, `active`, `currency`, `shareQuotaEqually`. The slug is immutable |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}` | |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/members` | Paginated |
+| `POST` | `/v1/tenants/{tenantID}/organizations/{orgID}/members` | `userId` **or** `user{provider,subject,…}`, plus `roleIds[]` and/or `builtinRoles[]` |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}` | |
+| `PUT` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}/roles` | Full replacement of the role set |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}/members/{membershipID}` | |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles` | Builtin and custom roles |
+| `POST` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles` | Custom role |
+| `GET` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | |
+| `PUT` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | Custom roles only |
+| `DELETE` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles/{roleID}` | Custom roles only |
+| `GET` | `/v1/tenants/{tenantID}/users` | `?provider=&subject=` for an exact lookup, otherwise `?search=&active=&page=&limit=` |
+| `PUT` | `/v1/tenants/{tenantID}/users` | Idempotent upsert on `(provider, subject)`: `201` when created, `200` otherwise |
+| `GET` | `/v1/tenants/{tenantID}/users/{userID}` | |
+| `PATCH` | `/v1/tenants/{tenantID}/users/{userID}` | `email`, `displayName`, `active` |
+
+Users hang from the tenant because `(provider, subject)` is only unique within
+one: the same person signing in on two tenants owns two distinct accounts.
+
+### Single-tenant instances
+
+A default installation owns exactly one tenant, `default`, created by the schema
+migration. It is not visible to end users — no subdomain, no change of URL — but
+it is the `{tenantID}` every route above needs. A control plane discovers it
+with `GET /v1/tenants?slug=default`, then uses that identifier throughout.
+
+Creating a second tenant is refused with `409` while
+`XOLO_MULTITENANCY_ENABLED` is false: no hostname would resolve to it, so its
+organizations would be unreachable.
 
 Payloads are JSON in camelCase, timestamps are RFC 3339, and collections are
 returned as `{"items": […], "page": 1, "limit": 50, "total": 123}`. Unknown
@@ -92,14 +119,14 @@ fields are rejected so a misspelled field is reported instead of ignored.
 Every error uses the same envelope:
 
 ```json
-{"error": {"code": "conflict", "message": "tenant with slug \"acme\" already exists (id: c9m2…)"}}
+{"error": {"code": "conflict", "message": "organization with slug \"acme\" already exists in this tenant (id: c9m2…)"}}
 ```
 
 | Code | HTTP | Cause |
 |---|---|---|
 | `invalid_request` | 400 | Malformed body, unknown field, invalid query parameter |
 | `unauthorized` | 401 | No verified client certificate |
-| `not_found` | 404 | Unknown resource, or a resource belonging to another tenant |
+| `not_found` | 404 | Unknown resource, or a resource belonging to another tenant or organization |
 | `method_not_allowed` | 405 | Known resource, wrong method |
 | `conflict` | 409 | Existing resource, or a business invariant that refuses the change |
 | `unprocessable` | 422 | Well-formed value refused by the domain |
@@ -111,15 +138,15 @@ server-side.
 
 ## Identity model
 
-A user is identified by its `provider` + `subject` tuple, the same key
-interactive authentication uses, so a provisioned user can log in afterwards.
-The API deliberately offers no email-based identity: `email` is a profile field,
-never an identifier.
+A user is identified by its `provider` + `subject` tuple **within its tenant**,
+the same key interactive authentication uses, so a provisioned user can log in
+afterwards. The API deliberately offers no email-based identity: `email` is a
+profile field, never an identifier.
 
 ### Provisioning ahead of the first sign-in
 
-`POST /v1/tenants` creates its owner before that person ever signs in, so the
-account already exists when they do. That requires the caller to know their
+`POST /v1/tenants/{tenantID}/organizations` creates its owner before that person
+ever signs in, so the account already exists when they do. That requires the caller to know their
 `subject` — the identifier the identity provider assigns them — in advance. It
 works when the control plane also owns the identity provider, or derives the
 subject deterministically.
@@ -128,37 +155,44 @@ When the subject cannot be known ahead of time, do not disable
 `XOLO_HTTP_AUTHN_AUTO_CREATE_USERS`: it would lock those people out. Use
 `XOLO_HTTP_AUTHN_ACTIVE_BY_DEFAULT=false` instead. The account is then created
 on first sign-in but stays inactive and grants nothing. The control plane picks
-it up with `GET /v1/users?active=false`, attaches it to a tenant with
-`POST /v1/tenants/{tenantID}/members`, and enables it with
-`PATCH /v1/users/{userID} {"active": true}`.
+it up with `GET /v1/tenants/{tenantID}/users?active=false`, attaches it to an
+organization with `POST /v1/tenants/{tenantID}/organizations/{orgID}/members`,
+and enables it with
+`PATCH /v1/tenants/{tenantID}/users/{userID} {"active": true}`.
 
 ## Invariants
 
-- Provisioning a tenant administrator **never** grants platform-wide privileges.
+- Provisioning an organization administrator **never** grants platform-wide privileges.
   A user created through this API receives exactly the `user` platform role, and
   the platform roles of an existing user are never modified.
 - The addresses listed in `XOLO_HTTP_AUTHN_DEFAULT_ADMINS` are reserved: writing
   one of them on a user is refused with `422`. The authentication bridge grants
   the platform admin role to whoever signs in with such an address, so accepting
   it here would be an indirect privilege escalation.
-- A tenant always keeps at least one owner: removing or downgrading its last one
-  is refused with `409`.
-- A role can only be assigned to a membership of the tenant it belongs to.
+- An organization always keeps at least one owner: removing or downgrading its
+  last one is refused with `409`.
+- A role can only be assigned to a membership of the organization it belongs to.
   Anything else is `422`, and no role is modified.
-- A membership or role belonging to another tenant is reported as `404`.
+- A membership or role belonging to another organization is reported as `404`,
+  and so is an organization or a user belonging to another tenant.
+- A user is always resolved inside the organization's own tenant, which is what
+  makes cross-tenant membership impossible.
+- The `default` tenant can neither be deleted nor deactivated: it is the tenant
+  every single-tenant instance resolves to.
 - Builtin roles cannot be modified nor deleted.
 - Only permission codes present in the RBAC catalog are accepted.
 
 ## Reconciliation
 
-Identifiers are stable, `PUT /v1/users` is idempotent, `POST /v1/tenants` on an
-existing slug answers `409` while including the existing identifier, and the
-lookup endpoints allow the current state to be read back in full. The single
-side effect of `POST /v1/tenants` is documented: it creates the builtin roles of
-the tenant.
+Identifiers are stable, `PUT /v1/tenants/{tenantID}/users` is idempotent,
+creating a tenant or an organization on an existing slug answers `409` while
+including the existing identifier, and the lookup endpoints allow the current
+state to be read back in full. The single side effect of
+`POST /v1/tenants/{tenantID}/organizations` is documented: it creates the
+builtin roles of the organization.
 
-`CreateTenant` orchestrates several stores, and the ports expose no cross-store
-transaction. Any failure after the organization row exists triggers a
+`CreateOrganization` orchestrates several stores, and the ports expose no
+cross-store transaction. Any failure after the organization row exists triggers a
 best-effort compensation (the organization is deleted, memberships cascade),
 logged if it fails in turn. A pre-existing user is never deleted. A proper
 `port.TxManager` would be the clean fix; it is out of the MVP scope.
@@ -200,7 +234,13 @@ curl -sk https://localhost:3003/v1/permissions
 
 # Accepted
 curl -s --cacert dev-pki/ca.crt --cert dev-pki/client.crt --key dev-pki/client.key \
-  -X POST https://localhost:3003/v1/tenants \
+  "https://localhost:3003/v1/tenants?slug=default"
+
+# Then, with the identifier it returned:
+TENANT=... # the id read above
+
+curl -s --cacert dev-pki/ca.crt --cert dev-pki/client.crt --key dev-pki/client.key \
+  -X POST "https://localhost:3003/v1/tenants/$TENANT/organizations" \
   -d '{"slug":"acme","name":"Acme","owner":{"provider":"openid-connect","subject":"sub-123","email":"owner@acme.tld","displayName":"Owner"}}'
 ```
 

--- a/internal/provisionning/handler/v1/dto.go
+++ b/internal/provisionning/handler/v1/dto.go
@@ -10,11 +10,34 @@ import (
 // The API exposes its own representations: the domain interfaces are never
 // serialized directly, so the wire contract stays stable when the domain moves.
 //
-// The external vocabulary is "tenant" where the domain says "organization". No
-// Tenant business object exists: it is only a naming choice of this transport.
+// The resource hierarchy mirrors the domain: a tenant owns organizations and
+// users, an organization owns members and roles.
 
 type tenantDTO struct {
+	ID          string    `json:"id"`
+	Slug        string    `json:"slug"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Active      bool      `json:"active"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func newTenantDTO(tenant model.Tenant) tenantDTO {
+	return tenantDTO{
+		ID:          string(tenant.ID()),
+		Slug:        tenant.Slug(),
+		Name:        tenant.Name(),
+		Description: tenant.Description(),
+		Active:      tenant.Active(),
+		CreatedAt:   tenant.CreatedAt(),
+		UpdatedAt:   tenant.UpdatedAt(),
+	}
+}
+
+type organizationDTO struct {
 	ID                string    `json:"id"`
+	TenantID          string    `json:"tenantId"`
 	Slug              string    `json:"slug"`
 	Name              string    `json:"name"`
 	Description       string    `json:"description"`
@@ -25,9 +48,10 @@ type tenantDTO struct {
 	UpdatedAt         time.Time `json:"updatedAt"`
 }
 
-func newTenantDTO(org model.Organization) tenantDTO {
-	return tenantDTO{
+func newOrganizationDTO(org model.Organization) organizationDTO {
+	return organizationDTO{
 		ID:                string(org.ID()),
+		TenantID:          string(org.TenantID()),
 		Slug:              org.Slug(),
 		Name:              org.Name(),
 		Description:       org.Description(),
@@ -99,9 +123,9 @@ type modelGrantDTO struct {
 }
 
 type roleDTO struct {
-	ID          string          `json:"id"`
-	TenantID    string          `json:"tenantId"`
-	Name        string          `json:"name"`
+	ID             string          `json:"id"`
+	OrganizationID string          `json:"organizationId"`
+	Name           string          `json:"name"`
 	Description string          `json:"description"`
 	Builtin     bool            `json:"builtin"`
 	BuiltinKind string          `json:"builtinKind,omitempty"`
@@ -123,8 +147,8 @@ func newRoleDTO(role model.Role) roleDTO {
 	}
 
 	return roleDTO{
-		ID:          string(role.ID()),
-		TenantID:    string(role.OrgID()),
+		ID:             string(role.ID()),
+		OrganizationID: string(role.OrgID()),
 		Name:        role.Name(),
 		Description: role.Description(),
 		Builtin:     role.Builtin(),
@@ -160,9 +184,9 @@ func newRoleRefDTOs(roles []model.Role) []roleRefDTO {
 }
 
 type membershipDTO struct {
-	ID        string       `json:"id"`
-	TenantID  string       `json:"tenantId"`
-	UserID    string       `json:"userId"`
+	ID             string       `json:"id"`
+	OrganizationID string       `json:"organizationId"`
+	UserID         string       `json:"userId"`
 	User      *userRefDTO  `json:"user,omitempty"`
 	Roles     []roleRefDTO `json:"roles"`
 	CreatedAt time.Time    `json:"createdAt"`
@@ -170,8 +194,8 @@ type membershipDTO struct {
 
 func newMembershipDTO(membership model.Membership) membershipDTO {
 	dto := membershipDTO{
-		ID:        string(membership.ID()),
-		TenantID:  string(membership.OrgID()),
+		ID:             string(membership.ID()),
+		OrganizationID: string(membership.OrgID()),
 		UserID:    string(membership.UserID()),
 		Roles:     newRoleRefDTOs(membership.Roles()),
 		CreatedAt: membership.CreatedAt(),
@@ -248,6 +272,19 @@ type userIdentityRequest struct {
 }
 
 type createTenantRequest struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Active      *bool  `json:"active"`
+}
+
+type updateTenantRequest struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Active      *bool   `json:"active"`
+}
+
+type createOrganizationRequest struct {
 	Slug        string               `json:"slug"`
 	Name        string               `json:"name"`
 	Description string               `json:"description"`
@@ -256,7 +293,7 @@ type createTenantRequest struct {
 	Owner       *userIdentityRequest `json:"owner"`
 }
 
-type updateTenantRequest struct {
+type updateOrganizationRequest struct {
 	Name              *string `json:"name"`
 	Description       *string `json:"description"`
 	Active            *bool   `json:"active"`

--- a/internal/provisionning/handler/v1/handler.go
+++ b/internal/provisionning/handler/v1/handler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/service"
 )
 
@@ -44,22 +45,32 @@ func NewHandler(provisioning *service.ProvisioningService) *Handler {
 	h.mux.HandleFunc("PATCH /v1/tenants/{tenantID}", h.handleUpdateTenant)
 	h.mux.HandleFunc("DELETE /v1/tenants/{tenantID}", h.handleDeleteTenant)
 
-	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/members", h.handleListMembers)
-	h.mux.HandleFunc("POST /v1/tenants/{tenantID}/members", h.handleAddMember)
-	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/members/{membershipID}", h.handleGetMember)
-	h.mux.HandleFunc("DELETE /v1/tenants/{tenantID}/members/{membershipID}", h.handleRemoveMember)
-	h.mux.HandleFunc("PUT /v1/tenants/{tenantID}/members/{membershipID}/roles", h.handleSetMemberRoles)
+	const orgPath = "/v1/tenants/{tenantID}/organizations"
 
-	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/roles", h.handleListRoles)
-	h.mux.HandleFunc("POST /v1/tenants/{tenantID}/roles", h.handleCreateRole)
-	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/roles/{roleID}", h.handleGetRole)
-	h.mux.HandleFunc("PUT /v1/tenants/{tenantID}/roles/{roleID}", h.handleUpdateRole)
-	h.mux.HandleFunc("DELETE /v1/tenants/{tenantID}/roles/{roleID}", h.handleDeleteRole)
+	h.mux.HandleFunc("GET "+orgPath, h.handleListOrganizations)
+	h.mux.HandleFunc("POST "+orgPath, h.handleCreateOrganization)
+	h.mux.HandleFunc("GET "+orgPath+"/{orgID}", h.handleGetOrganization)
+	h.mux.HandleFunc("PATCH "+orgPath+"/{orgID}", h.handleUpdateOrganization)
+	h.mux.HandleFunc("DELETE "+orgPath+"/{orgID}", h.handleDeleteOrganization)
 
-	h.mux.HandleFunc("GET /v1/users", h.handleListUsers)
-	h.mux.HandleFunc("PUT /v1/users", h.handlePutUser)
-	h.mux.HandleFunc("GET /v1/users/{userID}", h.handleGetUser)
-	h.mux.HandleFunc("PATCH /v1/users/{userID}", h.handleUpdateUser)
+	h.mux.HandleFunc("GET "+orgPath+"/{orgID}/members", h.handleListMembers)
+	h.mux.HandleFunc("POST "+orgPath+"/{orgID}/members", h.handleAddMember)
+	h.mux.HandleFunc("GET "+orgPath+"/{orgID}/members/{membershipID}", h.handleGetMember)
+	h.mux.HandleFunc("DELETE "+orgPath+"/{orgID}/members/{membershipID}", h.handleRemoveMember)
+	h.mux.HandleFunc("PUT "+orgPath+"/{orgID}/members/{membershipID}/roles", h.handleSetMemberRoles)
+
+	h.mux.HandleFunc("GET "+orgPath+"/{orgID}/roles", h.handleListRoles)
+	h.mux.HandleFunc("POST "+orgPath+"/{orgID}/roles", h.handleCreateRole)
+	h.mux.HandleFunc("GET "+orgPath+"/{orgID}/roles/{roleID}", h.handleGetRole)
+	h.mux.HandleFunc("PUT "+orgPath+"/{orgID}/roles/{roleID}", h.handleUpdateRole)
+	h.mux.HandleFunc("DELETE "+orgPath+"/{orgID}/roles/{roleID}", h.handleDeleteRole)
+
+	// Users hang from the tenant: (provider, subject) is only unique within
+	// one, so an instance-wide /v1/users upsert would have no key to act on.
+	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/users", h.handleListUsers)
+	h.mux.HandleFunc("PUT /v1/tenants/{tenantID}/users", h.handlePutUser)
+	h.mux.HandleFunc("GET /v1/tenants/{tenantID}/users/{userID}", h.handleGetUser)
+	h.mux.HandleFunc("PATCH /v1/tenants/{tenantID}/users/{userID}", h.handleUpdateUser)
 
 	// Catch-all so an unknown route answers with the same error envelope as
 	// everything else.
@@ -155,6 +166,40 @@ func pagination(r *http.Request) (page, limit int, ok bool) {
 	}
 
 	return page, limit, true
+}
+
+// resolveTenant reads the {tenantID} path segment and loads the tenant. It
+// writes the error response itself and reports whether the caller may proceed,
+// so every nested handler starts from a tenant that is known to exist.
+func (h *Handler) resolveTenant(w http.ResponseWriter, r *http.Request) (model.Tenant, bool) {
+	ctx := r.Context()
+
+	tenant, err := h.provisioning.GetTenant(ctx, model.TenantID(r.PathValue("tenantID")))
+	if err != nil {
+		writeServiceError(ctx, w, err, "tenant not found")
+		return nil, false
+	}
+
+	return tenant, true
+}
+
+// resolveOrganization loads the {orgID} of the {tenantID}. An organization
+// belonging to another tenant is reported as not found.
+func (h *Handler) resolveOrganization(w http.ResponseWriter, r *http.Request) (model.Organization, bool) {
+	ctx := r.Context()
+
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return nil, false
+	}
+
+	org, err := h.provisioning.GetOrganization(ctx, tenant.ID(), model.OrgID(r.PathValue("orgID")))
+	if err != nil {
+		writeServiceError(ctx, w, err, "organization not found")
+		return nil, false
+	}
+
+	return org, true
 }
 
 func writeInvalidPagination(w http.ResponseWriter) {

--- a/internal/provisionning/handler/v1/handler_test.go
+++ b/internal/provisionning/handler/v1/handler_test.go
@@ -2,22 +2,24 @@ package v1_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	_ "github.com/ncruces/go-sqlite3/embed"
+	"github.com/ncruces/go-sqlite3/gormlite"
 	xologorm "github.com/xolo-gateway/xolo/internal/adapter/gorm"
+	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/rbac"
 	"github.com/xolo-gateway/xolo/internal/core/service"
 	v1 "github.com/xolo-gateway/xolo/internal/provisionning/handler/v1"
-	_ "github.com/ncruces/go-sqlite3/embed"
-	"github.com/ncruces/go-sqlite3/gormlite"
 	gormpkg "gorm.io/gorm"
 )
 
-func newTestHandler(t *testing.T) (*v1.Handler, *gormpkg.DB) {
+func newTestHandler(t *testing.T) (handler *v1.Handler, db *gormpkg.DB, tenantBase string) {
 	t.Helper()
 
 	db, err := gormpkg.Open(gormlite.Open(":memory:"), &gormpkg.Config{})
@@ -27,7 +29,16 @@ func newTestHandler(t *testing.T) (*v1.Handler, *gormpkg.DB) {
 
 	store := xologorm.NewStore(db)
 
-	return v1.NewHandler(service.NewProvisioningService(store, store, store)), db
+	// The schema migration creates the default tenant. These tests exercise the
+	// resources nested under a tenant, so every path is built from it.
+	tenant, err := store.GetTenantBySlug(context.Background(), model.DefaultTenantSlug)
+	if err != nil {
+		t.Fatalf("get default tenant: %v", err)
+	}
+
+	handler = v1.NewHandler(service.NewProvisioningService(store, store, store, store))
+
+	return handler, db, "/v1/tenants/" + string(tenant.ID())
 }
 
 // call performs a request against the handler. body may be nil, a string or any
@@ -95,9 +106,12 @@ func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, want string) 
 	}
 }
 
-// createTenant provisions a tenant through the API and returns its identifier.
-func createTenant(t *testing.T, handler http.Handler, slug string, withOwner bool) (tenantID, membershipID string) {
+// createOrganization provisions an organization through the API and returns its
+// identifier.
+func createOrganization(t *testing.T, handler http.Handler, tenantBase, slug string, withOwner bool) (orgID, membershipID string) {
 	t.Helper()
+
+	orgBase := tenantBase + "/organizations"
 
 	payload := map[string]any{"slug": slug, "name": strings.ToUpper(slug)}
 	if withOwner {
@@ -109,26 +123,26 @@ func createTenant(t *testing.T, handler http.Handler, slug string, withOwner boo
 		}
 	}
 
-	rec := call(t, handler, http.MethodPost, "/v1/tenants", payload)
+	rec := call(t, handler, http.MethodPost, orgBase, payload)
 	assertStatus(t, rec, http.StatusCreated)
 
 	body := decodeBody(t, rec)
 
-	tenant, ok := body["tenant"].(map[string]any)
+	org, ok := body["organization"].(map[string]any)
 	if !ok {
-		t.Fatalf("missing tenant in response: %s", rec.Body.String())
+		t.Fatalf("missing organization in response: %s", rec.Body.String())
 	}
-	tenantID, _ = tenant["id"].(string)
+	orgID, _ = org["id"].(string)
 
 	if membership, ok := body["ownerMembership"].(map[string]any); ok {
 		membershipID, _ = membership["id"].(string)
 	}
 
-	return tenantID, membershipID
+	return orgID, membershipID
 }
 
 func TestHealthzAndPermissions(t *testing.T) {
-	handler, _ := newTestHandler(t)
+	handler, _, _ := newTestHandler(t)
 
 	rec := call(t, handler, http.MethodGet, "/v1/healthz", nil)
 	assertStatus(t, rec, http.StatusOK)
@@ -145,11 +159,12 @@ func TestHealthzAndPermissions(t *testing.T) {
 	}
 }
 
-func TestTenantEndpoints(t *testing.T) {
-	t.Run("creates a tenant with its initial owner", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+func TestOrganizationEndpoints(t *testing.T) {
+	t.Run("creates an organization with its initial owner", func(t *testing.T) {
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants", map[string]any{
+		rec := call(t, handler, http.MethodPost, orgBase, map[string]any{
 			"slug": "acme",
 			"name": "Acme",
 			"owner": map[string]any{
@@ -191,11 +206,12 @@ func TestTenantEndpoints(t *testing.T) {
 	})
 
 	t.Run("reports a duplicate slug as a conflict", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants", map[string]any{"slug": "acme", "name": "Acme"})
+		rec := call(t, handler, http.MethodPost, orgBase, map[string]any{"slug": "acme", "name": "Acme"})
 		assertStatus(t, rec, http.StatusConflict)
 		assertErrorCode(t, rec, "conflict")
 
@@ -205,7 +221,8 @@ func TestTenantEndpoints(t *testing.T) {
 	})
 
 	t.Run("rejects invalid payloads", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
 		cases := map[string]struct {
 			body   any
@@ -221,47 +238,49 @@ func TestTenantEndpoints(t *testing.T) {
 
 		for name, testCase := range cases {
 			t.Run(name, func(t *testing.T) {
-				rec := call(t, handler, http.MethodPost, "/v1/tenants", testCase.body)
+				rec := call(t, handler, http.MethodPost, orgBase, testCase.body)
 				assertStatus(t, rec, testCase.status)
 				assertErrorCode(t, rec, testCase.code)
 			})
 		}
 	})
 
-	t.Run("reads, updates and deletes a tenant", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+	t.Run("reads, updates and deletes an organization", func(t *testing.T) {
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID, nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"/"+tenantID, nil)
 		assertStatus(t, rec, http.StatusOK)
 
-		rec = call(t, handler, http.MethodPatch, "/v1/tenants/"+tenantID, map[string]any{"name": "Acme Corporation"})
+		rec = call(t, handler, http.MethodPatch, orgBase+"/"+tenantID, map[string]any{"name": "Acme Corporation"})
 		assertStatus(t, rec, http.StatusOK)
 		if name := decodeBody(t, rec)["name"]; name != "Acme Corporation" {
 			t.Errorf("name: got %v", name)
 		}
 
-		rec = call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID, nil)
+		rec = call(t, handler, http.MethodDelete, orgBase+"/"+tenantID, nil)
 		assertStatus(t, rec, http.StatusNoContent)
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID, nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"/"+tenantID, nil)
 		assertStatus(t, rec, http.StatusNotFound)
 		assertErrorCode(t, rec, "not_found")
 	})
 
 	t.Run("looks a tenant up by slug", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		createTenant(t, handler, "acme", false)
+		createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants?slug=acme", nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"?slug=acme", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(1) {
 			t.Errorf("total: got %v, want 1", total)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants?slug=unknown", nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"?slug=unknown", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(0) {
 			t.Errorf("total: got %v, want 0", total)
@@ -269,9 +288,10 @@ func TestTenantEndpoints(t *testing.T) {
 	})
 
 	t.Run("rejects invalid pagination", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants?limit=10000", nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"?limit=10000", nil)
 		assertStatus(t, rec, http.StatusBadRequest)
 		assertErrorCode(t, rec, "invalid_request")
 	})
@@ -290,19 +310,20 @@ func TestMemberEndpoints(t *testing.T) {
 	}
 
 	t.Run("adds, reads, updates and removes a member", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", true)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", true)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/members", newMember("sub-member"))
+		rec := call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/members", newMember("sub-member"))
 		assertStatus(t, rec, http.StatusCreated)
 
 		membershipID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID+"/members/"+membershipID, nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"/"+tenantID+"/members/"+membershipID, nil)
 		assertStatus(t, rec, http.StatusOK)
 
-		rec = call(t, handler, http.MethodPut, "/v1/tenants/"+tenantID+"/members/"+membershipID+"/roles",
+		rec = call(t, handler, http.MethodPut, orgBase+"/"+tenantID+"/members/"+membershipID+"/roles",
 			map[string]any{"builtinRoles": []string{"admin"}})
 		assertStatus(t, rec, http.StatusOK)
 
@@ -311,88 +332,93 @@ func TestMemberEndpoints(t *testing.T) {
 			t.Errorf("roles: got %v", roles)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID+"/members", nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"/"+tenantID+"/members", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(2) {
 			t.Errorf("total: got %v, want 2", total)
 		}
 
-		rec = call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID+"/members/"+membershipID, nil)
+		rec = call(t, handler, http.MethodDelete, orgBase+"/"+tenantID+"/members/"+membershipID, nil)
 		assertStatus(t, rec, http.StatusNoContent)
 	})
 
 	t.Run("reports a duplicate membership as a conflict", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", true)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", true)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/members", newMember("sub-member"))
+		rec := call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/members", newMember("sub-member"))
 		assertStatus(t, rec, http.StatusCreated)
 
-		rec = call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/members", newMember("sub-member"))
+		rec = call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/members", newMember("sub-member"))
 		assertStatus(t, rec, http.StatusConflict)
 		assertErrorCode(t, rec, "conflict")
 	})
 
 	t.Run("refuses a role belonging to another tenant", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		acmeID, _ := createTenant(t, handler, "acme", true)
-		otherID, _ := createTenant(t, handler, "other", false)
+		acmeID, _ := createOrganization(t, handler, tenantBase, "acme", true)
+		otherID, _ := createOrganization(t, handler, tenantBase, "other", false)
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants/"+otherID+"/roles", nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"/"+otherID+"/roles", nil)
 		assertStatus(t, rec, http.StatusOK)
 		otherRoleID := decodeBody(t, rec)["items"].([]any)[0].(map[string]any)["id"].(string)
 
-		rec = call(t, handler, http.MethodPost, "/v1/tenants/"+acmeID+"/members", newMember("sub-member"))
+		rec = call(t, handler, http.MethodPost, orgBase+"/"+acmeID+"/members", newMember("sub-member"))
 		assertStatus(t, rec, http.StatusCreated)
 		membershipID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodPut, "/v1/tenants/"+acmeID+"/members/"+membershipID+"/roles",
+		rec = call(t, handler, http.MethodPut, orgBase+"/"+acmeID+"/members/"+membershipID+"/roles",
 			map[string]any{"roleIds": []string{otherRoleID}})
 		assertStatus(t, rec, http.StatusUnprocessableEntity)
 		assertErrorCode(t, rec, "unprocessable")
 	})
 
 	t.Run("refuses to drop the last owner", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, ownerMembershipID := createTenant(t, handler, "acme", true)
+		tenantID, ownerMembershipID := createOrganization(t, handler, tenantBase, "acme", true)
 
-		rec := call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID+"/members/"+ownerMembershipID, nil)
+		rec := call(t, handler, http.MethodDelete, orgBase+"/"+tenantID+"/members/"+ownerMembershipID, nil)
 		assertStatus(t, rec, http.StatusConflict)
 		assertErrorCode(t, rec, "conflict")
 
-		rec = call(t, handler, http.MethodPut, "/v1/tenants/"+tenantID+"/members/"+ownerMembershipID+"/roles",
+		rec = call(t, handler, http.MethodPut, orgBase+"/"+tenantID+"/members/"+ownerMembershipID+"/roles",
 			map[string]any{"builtinRoles": []string{"member"}})
 		assertStatus(t, rec, http.StatusConflict)
 	})
 
 	t.Run("hides resources of another tenant", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		acmeID, acmeMembershipID := createTenant(t, handler, "acme", true)
-		otherID, _ := createTenant(t, handler, "other", false)
+		acmeID, acmeMembershipID := createOrganization(t, handler, tenantBase, "acme", true)
+		otherID, _ := createOrganization(t, handler, tenantBase, "other", false)
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants/"+otherID+"/members/"+acmeMembershipID, nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"/"+otherID+"/members/"+acmeMembershipID, nil)
 		assertStatus(t, rec, http.StatusNotFound)
 		assertErrorCode(t, rec, "not_found")
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+acmeID+"/members/nope", nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"/"+acmeID+"/members/nope", nil)
 		assertStatus(t, rec, http.StatusNotFound)
 
-		rec = call(t, handler, http.MethodGet, "/v1/tenants/nope/members", nil)
+		rec = call(t, handler, http.MethodGet, orgBase+"/nope/members", nil)
 		assertStatus(t, rec, http.StatusNotFound)
 	})
 }
 
 func TestRoleEndpoints(t *testing.T) {
 	t.Run("creates, updates and deletes a custom role", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/roles", map[string]any{
+		rec := call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/roles", map[string]any{
 			"name":        "auditor",
 			"permissions": []string{"usage:read"},
 		})
@@ -400,7 +426,7 @@ func TestRoleEndpoints(t *testing.T) {
 
 		roleID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodPut, "/v1/tenants/"+tenantID+"/roles/"+roleID, map[string]any{
+		rec = call(t, handler, http.MethodPut, orgBase+"/"+tenantID+"/roles/"+roleID, map[string]any{
 			"permissions": []string{"usage:read", "members:read"},
 		})
 		assertStatus(t, rec, http.StatusOK)
@@ -408,16 +434,17 @@ func TestRoleEndpoints(t *testing.T) {
 			t.Errorf("permissions: got %v", permissions)
 		}
 
-		rec = call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID+"/roles/"+roleID, nil)
+		rec = call(t, handler, http.MethodDelete, orgBase+"/"+tenantID+"/roles/"+roleID, nil)
 		assertStatus(t, rec, http.StatusNoContent)
 	})
 
 	t.Run("refuses an unknown permission", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/roles", map[string]any{
+		rec := call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/roles", map[string]any{
 			"name":        "bogus",
 			"permissions": []string{"not:a:permission"},
 		})
@@ -426,24 +453,26 @@ func TestRoleEndpoints(t *testing.T) {
 	})
 
 	t.Run("refuses a duplicate role name", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/roles", map[string]any{"name": "auditor"})
+		rec := call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/roles", map[string]any{"name": "auditor"})
 		assertStatus(t, rec, http.StatusCreated)
 
-		rec = call(t, handler, http.MethodPost, "/v1/tenants/"+tenantID+"/roles", map[string]any{"name": "auditor"})
+		rec = call(t, handler, http.MethodPost, orgBase+"/"+tenantID+"/roles", map[string]any{"name": "auditor"})
 		assertStatus(t, rec, http.StatusConflict)
 		assertErrorCode(t, rec, "conflict")
 	})
 
 	t.Run("protects builtin roles", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
+		orgBase := tenantBase + "/organizations"
 
-		tenantID, _ := createTenant(t, handler, "acme", false)
+		tenantID, _ := createOrganization(t, handler, tenantBase, "acme", false)
 
-		rec := call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID+"/roles", nil)
+		rec := call(t, handler, http.MethodGet, orgBase+"/"+tenantID+"/roles", nil)
 		assertStatus(t, rec, http.StatusOK)
 
 		var builtinID string
@@ -457,11 +486,11 @@ func TestRoleEndpoints(t *testing.T) {
 			t.Fatal("no builtin owner role found")
 		}
 
-		rec = call(t, handler, http.MethodPut, "/v1/tenants/"+tenantID+"/roles/"+builtinID, map[string]any{"name": "hacked"})
+		rec = call(t, handler, http.MethodPut, orgBase+"/"+tenantID+"/roles/"+builtinID, map[string]any{"name": "hacked"})
 		assertStatus(t, rec, http.StatusConflict)
 		assertErrorCode(t, rec, "conflict")
 
-		rec = call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID+"/roles/"+builtinID, nil)
+		rec = call(t, handler, http.MethodDelete, orgBase+"/"+tenantID+"/roles/"+builtinID, nil)
 		assertStatus(t, rec, http.StatusConflict)
 	})
 }
@@ -475,13 +504,13 @@ func TestUserEndpoints(t *testing.T) {
 	}
 
 	t.Run("upserts a user idempotently", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
 
-		rec := call(t, handler, http.MethodPut, "/v1/users", identity)
+		rec := call(t, handler, http.MethodPut, tenantBase+"/users", identity)
 		assertStatus(t, rec, http.StatusCreated)
 		userID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodPut, "/v1/users", identity)
+		rec = call(t, handler, http.MethodPut, tenantBase+"/users", identity)
 		assertStatus(t, rec, http.StatusOK)
 		if id := decodeBody(t, rec)["id"]; id != userID {
 			t.Errorf("id: got %v, want %q", id, userID)
@@ -489,59 +518,59 @@ func TestUserEndpoints(t *testing.T) {
 	})
 
 	t.Run("looks a user up by identity", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
 
-		call(t, handler, http.MethodPut, "/v1/users", identity)
+		call(t, handler, http.MethodPut, tenantBase+"/users", identity)
 
-		rec := call(t, handler, http.MethodGet, "/v1/users?provider=openid-connect&subject=sub-1", nil)
+		rec := call(t, handler, http.MethodGet, tenantBase+"/users?provider=openid-connect&subject=sub-1", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(1) {
 			t.Errorf("total: got %v, want 1", total)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/users?provider=openid-connect&subject=unknown", nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users?provider=openid-connect&subject=unknown", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(0) {
 			t.Errorf("total: got %v, want 0", total)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/users?provider=openid-connect", nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users?provider=openid-connect", nil)
 		assertStatus(t, rec, http.StatusBadRequest)
 		assertErrorCode(t, rec, "invalid_request")
 	})
 
 	t.Run("updates and reads a user", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
 
-		rec := call(t, handler, http.MethodPut, "/v1/users", identity)
+		rec := call(t, handler, http.MethodPut, tenantBase+"/users", identity)
 		userID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodPatch, "/v1/users/"+userID, map[string]any{"displayName": "Renamed"})
+		rec = call(t, handler, http.MethodPatch, tenantBase+"/users/"+userID, map[string]any{"displayName": "Renamed"})
 		assertStatus(t, rec, http.StatusOK)
 		if name := decodeBody(t, rec)["displayName"]; name != "Renamed" {
 			t.Errorf("display name: got %v", name)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/users/"+userID, nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users/"+userID, nil)
 		assertStatus(t, rec, http.StatusOK)
 
-		rec = call(t, handler, http.MethodGet, "/v1/users/nope", nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users/nope", nil)
 		assertStatus(t, rec, http.StatusNotFound)
 	})
 
 	t.Run("filters on the active flag", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
 
 		active := false
-		call(t, handler, http.MethodPut, "/v1/users", identity)
-		call(t, handler, http.MethodPut, "/v1/users", map[string]any{
+		call(t, handler, http.MethodPut, tenantBase+"/users", identity)
+		call(t, handler, http.MethodPut, tenantBase+"/users", map[string]any{
 			"provider": "openid-connect",
 			"subject":  "sub-pending",
 			"email":    "pending@acme.tld",
 			"active":   active,
 		})
 
-		rec := call(t, handler, http.MethodGet, "/v1/users?active=false", nil)
+		rec := call(t, handler, http.MethodGet, tenantBase+"/users?active=false", nil)
 		assertStatus(t, rec, http.StatusOK)
 
 		items := decodeBody(t, rec)["items"].([]any)
@@ -552,28 +581,28 @@ func TestUserEndpoints(t *testing.T) {
 			t.Errorf("email: got %v", email)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/users?active=true", nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users?active=true", nil)
 		assertStatus(t, rec, http.StatusOK)
 		if total := decodeBody(t, rec)["total"]; total != float64(1) {
 			t.Errorf("active users: got %v, want 1", total)
 		}
 
-		rec = call(t, handler, http.MethodGet, "/v1/users?active=maybe", nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users?active=maybe", nil)
 		assertStatus(t, rec, http.StatusBadRequest)
 		assertErrorCode(t, rec, "invalid_request")
 	})
 
 	t.Run("never exposes platform role management", func(t *testing.T) {
-		handler, _ := newTestHandler(t)
+		handler, _, tenantBase := newTestHandler(t)
 
-		rec := call(t, handler, http.MethodPut, "/v1/users", identity)
+		rec := call(t, handler, http.MethodPut, tenantBase+"/users", identity)
 		userID := decodeBody(t, rec)["id"].(string)
 
-		rec = call(t, handler, http.MethodPatch, "/v1/users/"+userID, map[string]any{"platformRoles": []string{"admin"}})
+		rec = call(t, handler, http.MethodPatch, tenantBase+"/users/"+userID, map[string]any{"platformRoles": []string{"admin"}})
 		assertStatus(t, rec, http.StatusBadRequest)
 		assertErrorCode(t, rec, "invalid_request")
 
-		rec = call(t, handler, http.MethodGet, "/v1/users/"+userID, nil)
+		rec = call(t, handler, http.MethodGet, tenantBase+"/users/"+userID, nil)
 		roles := decodeBody(t, rec)["platformRoles"].([]any)
 		if len(roles) != 1 || roles[0] != "user" {
 			t.Errorf("platform roles: got %v, want [user]", roles)
@@ -582,7 +611,7 @@ func TestUserEndpoints(t *testing.T) {
 }
 
 func TestRoutingFallbacks(t *testing.T) {
-	handler, _ := newTestHandler(t)
+	handler, _, _ := newTestHandler(t)
 
 	rec := call(t, handler, http.MethodGet, "/v1/unknown", nil)
 	assertStatus(t, rec, http.StatusNotFound)
@@ -595,9 +624,10 @@ func TestRoutingFallbacks(t *testing.T) {
 // TestInternalErrorsDoNotLeak checks that an unexpected failure is reported as
 // a generic error: no SQL, no file path, no stack trace.
 func TestInternalErrorsDoNotLeak(t *testing.T) {
-	handler, db := newTestHandler(t)
+	handler, db, tenantBase := newTestHandler(t)
+	orgBase := tenantBase + "/organizations"
 
-	createTenant(t, handler, "acme", false)
+	createOrganization(t, handler, tenantBase, "acme", false)
 
 	sqlDB, err := db.DB()
 	if err != nil {
@@ -607,7 +637,7 @@ func TestInternalErrorsDoNotLeak(t *testing.T) {
 		t.Fatalf("close db: %v", err)
 	}
 
-	rec := call(t, handler, http.MethodGet, "/v1/tenants", nil)
+	rec := call(t, handler, http.MethodGet, orgBase, nil)
 	assertStatus(t, rec, http.StatusInternalServerError)
 	assertErrorCode(t, rec, "internal_error")
 
@@ -617,4 +647,178 @@ func TestInternalErrorsDoNotLeak(t *testing.T) {
 			t.Errorf("error body should not contain %q, got %s", leak, body)
 		}
 	}
+}
+
+// newMultiTenantHandler builds a handler allowed to provision tenants, as
+// XOLO_MULTITENANCY_ENABLED=true does.
+func newMultiTenantHandler(t *testing.T) (*v1.Handler, string) {
+	t.Helper()
+
+	db, err := gormpkg.Open(gormlite.Open(":memory:"), &gormpkg.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	store := xologorm.NewStore(db)
+
+	tenant, err := store.GetTenantBySlug(context.Background(), model.DefaultTenantSlug)
+	if err != nil {
+		t.Fatalf("get default tenant: %v", err)
+	}
+
+	handler := v1.NewHandler(service.NewProvisioningService(store, store, store, store,
+		service.WithMultiTenant(true),
+	))
+
+	return handler, string(tenant.ID())
+}
+
+func TestTenantEndpoints(t *testing.T) {
+	t.Run("single-tenant mode refuses to create a tenant", func(t *testing.T) {
+		handler, _, _ := newTestHandler(t)
+
+		rec := call(t, handler, http.MethodPost, "/v1/tenants", map[string]any{"slug": "acme", "name": "Acme"})
+		assertStatus(t, rec, http.StatusConflict)
+		assertErrorCode(t, rec, "conflict")
+
+		if message := decodeBody(t, rec)["error"].(map[string]any)["message"].(string); !strings.Contains(message, "single-tenant") {
+			t.Errorf("message should explain the mode, got %q", message)
+		}
+	})
+
+	t.Run("single-tenant mode still exposes its tenant", func(t *testing.T) {
+		handler, _, tenantBase := newTestHandler(t)
+
+		// A control plane discovers the identifier every nested route needs
+		// through the slug lookup, without any tenant having been created.
+		rec := call(t, handler, http.MethodGet, "/v1/tenants?slug="+model.DefaultTenantSlug, nil)
+		assertStatus(t, rec, http.StatusOK)
+
+		items, _ := decodeBody(t, rec)["items"].([]any)
+		if len(items) != 1 {
+			t.Fatalf("items: got %d, want 1", len(items))
+		}
+		if id, _ := items[0].(map[string]any)["id"].(string); !strings.HasSuffix(tenantBase, id) {
+			t.Errorf("id %q should be the one every path is built from (%q)", id, tenantBase)
+		}
+	})
+
+	t.Run("creates, reads, updates and deletes a tenant", func(t *testing.T) {
+		handler, _ := newMultiTenantHandler(t)
+
+		rec := call(t, handler, http.MethodPost, "/v1/tenants", map[string]any{
+			"slug": "acme", "name": "Acme", "description": "Acme Inc.",
+		})
+		assertStatus(t, rec, http.StatusCreated)
+
+		tenantID, _ := decodeBody(t, rec)["id"].(string)
+		if tenantID == "" {
+			t.Fatalf("missing tenant id: %s", rec.Body.String())
+		}
+
+		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID, nil)
+		assertStatus(t, rec, http.StatusOK)
+
+		rec = call(t, handler, http.MethodPatch, "/v1/tenants/"+tenantID, map[string]any{"name": "Acme Corporation"})
+		assertStatus(t, rec, http.StatusOK)
+		if name := decodeBody(t, rec)["name"]; name != "Acme Corporation" {
+			t.Errorf("name: got %v, want %q", name, "Acme Corporation")
+		}
+
+		rec = call(t, handler, http.MethodDelete, "/v1/tenants/"+tenantID, nil)
+		assertStatus(t, rec, http.StatusNoContent)
+
+		rec = call(t, handler, http.MethodGet, "/v1/tenants/"+tenantID, nil)
+		assertStatus(t, rec, http.StatusNotFound)
+	})
+
+	t.Run("reports a duplicate slug as a conflict carrying the existing id", func(t *testing.T) {
+		handler, defaultTenantID := newMultiTenantHandler(t)
+
+		rec := call(t, handler, http.MethodPost, "/v1/tenants",
+			map[string]any{"slug": model.DefaultTenantSlug, "name": "Another default"})
+		assertStatus(t, rec, http.StatusConflict)
+
+		if message := decodeBody(t, rec)["error"].(map[string]any)["message"].(string); !strings.Contains(message, defaultTenantID) {
+			t.Errorf("conflict message should carry %q, got %q", defaultTenantID, message)
+		}
+	})
+
+	t.Run("protects the default tenant", func(t *testing.T) {
+		handler, defaultTenantID := newMultiTenantHandler(t)
+
+		rec := call(t, handler, http.MethodDelete, "/v1/tenants/"+defaultTenantID, nil)
+		assertStatus(t, rec, http.StatusConflict)
+
+		rec = call(t, handler, http.MethodPatch, "/v1/tenants/"+defaultTenantID, map[string]any{"active": false})
+		assertStatus(t, rec, http.StatusConflict)
+	})
+
+	t.Run("rejects invalid payloads", func(t *testing.T) {
+		handler, _ := newMultiTenantHandler(t)
+
+		cases := map[string]struct {
+			body   any
+			status int
+			code   string
+		}{
+			"malformed json": {"{", http.StatusBadRequest, "invalid_request"},
+			"unknown field":  {map[string]any{"slug": "acme", "name": "Acme", "currency": "EUR"}, http.StatusBadRequest, "invalid_request"},
+			"invalid slug":   {map[string]any{"slug": "Acme Corp", "name": "Acme"}, http.StatusUnprocessableEntity, "unprocessable"},
+			"missing name":   {map[string]any{"slug": "acme"}, http.StatusUnprocessableEntity, "unprocessable"},
+		}
+
+		for name, testCase := range cases {
+			t.Run(name, func(t *testing.T) {
+				rec := call(t, handler, http.MethodPost, "/v1/tenants", testCase.body)
+				assertStatus(t, rec, testCase.status)
+				assertErrorCode(t, rec, testCase.code)
+			})
+		}
+	})
+
+	t.Run("hides the resources of another tenant", func(t *testing.T) {
+		handler, _ := newMultiTenantHandler(t)
+
+		rec := call(t, handler, http.MethodPost, "/v1/tenants", map[string]any{"slug": "acme", "name": "Acme"})
+		assertStatus(t, rec, http.StatusCreated)
+		otherTenantID, _ := decodeBody(t, rec)["id"].(string)
+
+		// An organization created in the default tenant must not be reachable
+		// through another tenant's path, even with the right identifier.
+		defaultBase := "/v1/tenants/" + func() string {
+			rec := call(t, handler, http.MethodGet, "/v1/tenants?slug="+model.DefaultTenantSlug, nil)
+			items, _ := decodeBody(t, rec)["items"].([]any)
+			id, _ := items[0].(map[string]any)["id"].(string)
+			return id
+		}()
+
+		orgID, _ := createOrganization(t, handler, defaultBase, "acme", false)
+
+		otherBase := "/v1/tenants/" + otherTenantID + "/organizations"
+
+		rec = call(t, handler, http.MethodGet, otherBase+"/"+orgID, nil)
+		assertStatus(t, rec, http.StatusNotFound)
+
+		rec = call(t, handler, http.MethodGet, otherBase+"/"+orgID+"/members", nil)
+		assertStatus(t, rec, http.StatusNotFound)
+
+		// The same slug is free on the other tenant: isolation, not collision.
+		rec = call(t, handler, http.MethodPost, otherBase, map[string]any{"slug": "acme", "name": "Acme"})
+		assertStatus(t, rec, http.StatusCreated)
+	})
+
+	t.Run("an unknown tenant is reported as not found", func(t *testing.T) {
+		handler, _, _ := newTestHandler(t)
+
+		for _, target := range []string{
+			"/v1/tenants/nope",
+			"/v1/tenants/nope/organizations",
+			"/v1/tenants/nope/users",
+		} {
+			rec := call(t, handler, http.MethodGet, target, nil)
+			assertStatus(t, rec, http.StatusNotFound)
+			assertErrorCode(t, rec, "not_found")
+		}
+	})
 }

--- a/internal/provisionning/handler/v1/members.go
+++ b/internal/provisionning/handler/v1/members.go
@@ -11,6 +11,11 @@ import (
 func (h *Handler) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	page, limit, ok := pagination(r)
 	if !ok {
 		writeInvalidPagination(w)
@@ -19,12 +24,12 @@ func (h *Handler) handleListMembers(w http.ResponseWriter, r *http.Request) {
 
 	offset := page - 1
 
-	members, total, err := h.provisioning.ListMembers(ctx, model.OrgID(r.PathValue("tenantID")), port.ListOrgMembersOptions{
+	members, total, err := h.provisioning.ListMembers(ctx, org.ID(), port.ListOrgMembersOptions{
 		Page:  &offset,
 		Limit: &limit,
 	})
 	if err != nil {
-		writeServiceError(ctx, w, err, "tenant not found")
+		writeServiceError(ctx, w, err, "organization not found")
 		return
 	}
 
@@ -38,6 +43,11 @@ func (h *Handler) handleListMembers(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleAddMember(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
 
 	var payload addMemberRequest
 	if !decodeJSON(w, r, &payload) {
@@ -55,7 +65,7 @@ func (h *Handler) handleAddMember(w http.ResponseWriter, r *http.Request) {
 		params.User = &user
 	}
 
-	membership, err := h.provisioning.AddMember(ctx, model.OrgID(r.PathValue("tenantID")), params)
+	membership, err := h.provisioning.AddMember(ctx, org.ID(), params)
 	if err != nil {
 		writeServiceError(ctx, w, err, "could not add member")
 		return
@@ -67,8 +77,13 @@ func (h *Handler) handleAddMember(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleGetMember(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	membership, err := h.provisioning.GetMember(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.MembershipID(r.PathValue("membershipID")),
 	)
 	if err != nil {
@@ -82,13 +97,18 @@ func (h *Handler) handleGetMember(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleSetMemberRoles(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	var payload setMemberRolesRequest
 	if !decodeJSON(w, r, &payload) {
 		return
 	}
 
 	membership, err := h.provisioning.SetMemberRoles(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.MembershipID(r.PathValue("membershipID")),
 		toRoleIDs(payload.RoleIDs),
 		payload.BuiltinRoles,
@@ -104,8 +124,13 @@ func (h *Handler) handleSetMemberRoles(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	err := h.provisioning.RemoveMember(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.MembershipID(r.PathValue("membershipID")),
 	)
 	if err != nil {

--- a/internal/provisionning/handler/v1/organizations.go
+++ b/internal/provisionning/handler/v1/organizations.go
@@ -1,0 +1,187 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/core/model"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+	"github.com/xolo-gateway/xolo/internal/core/service"
+)
+
+type createOrganizationResponse struct {
+	Organization organizationDTO `json:"organization"`
+
+	// Owner and Membership are present only when an initial owner was
+	// requested. OwnerCreated tells an external reconciler whether the identity
+	// already existed.
+	Owner        *userDTO       `json:"owner,omitempty"`
+	Membership   *membershipDTO `json:"ownerMembership,omitempty"`
+	OwnerCreated bool           `json:"ownerCreated"`
+}
+
+func (h *Handler) handleListOrganizations(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
+	// An exact slug lookup lets a reconciler read back the state it just
+	// declared without knowing the generated identifier.
+	if slug := r.URL.Query().Get("slug"); slug != "" {
+		org, err := h.provisioning.GetOrganizationBySlug(ctx, tenant.ID(), slug)
+		if err != nil {
+			if errors.Is(err, port.ErrNotFound) {
+				writeJSON(w, http.StatusOK, newListDTO([]organizationDTO{}, 1, 1, 0))
+				return
+			}
+			writeServiceError(ctx, w, err, "organization not found")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, newListDTO([]organizationDTO{newOrganizationDTO(org)}, 1, 1, 1))
+
+		return
+	}
+
+	page, limit, ok := pagination(r)
+	if !ok {
+		writeInvalidPagination(w)
+		return
+	}
+
+	offset := page - 1
+	tenantID := tenant.ID()
+
+	orgs, total, err := h.provisioning.ListOrganizations(ctx, port.ListOrgsOptions{
+		Page:     &offset,
+		Limit:    &limit,
+		TenantID: &tenantID,
+	})
+	if err != nil {
+		writeServiceError(ctx, w, err, "could not list organizations")
+		return
+	}
+
+	items := make([]organizationDTO, 0, len(orgs))
+	for _, org := range orgs {
+		items = append(items, newOrganizationDTO(org))
+	}
+
+	writeJSON(w, http.StatusOK, newListDTO(items, page, limit, total))
+}
+
+func (h *Handler) handleCreateOrganization(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
+	var payload createOrganizationRequest
+	if !decodeJSON(w, r, &payload) {
+		return
+	}
+
+	params := service.CreateOrganizationParams{
+		TenantID:    tenant.ID(),
+		Slug:        payload.Slug,
+		Name:        payload.Name,
+		Description: payload.Description,
+		Currency:    payload.Currency,
+		Active:      payload.Active,
+	}
+
+	if payload.Owner != nil {
+		owner := toIdentityParams(*payload.Owner)
+		params.Owner = &owner
+	}
+
+	result, err := h.provisioning.CreateOrganization(ctx, params)
+	if err != nil {
+		writeServiceError(ctx, w, err, "could not create organization")
+		return
+	}
+
+	response := createOrganizationResponse{
+		Organization: newOrganizationDTO(result.Org),
+		OwnerCreated: result.OwnerCreated,
+	}
+
+	if result.Owner != nil {
+		owner := newUserDTO(result.Owner)
+		response.Owner = &owner
+	}
+	if result.OwnerMembership != nil {
+		membership := newMembershipDTO(result.OwnerMembership)
+		response.Membership = &membership
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func (h *Handler) handleGetOrganization(w http.ResponseWriter, r *http.Request) {
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, newOrganizationDTO(org))
+}
+
+func (h *Handler) handleUpdateOrganization(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
+	var payload updateOrganizationRequest
+	if !decodeJSON(w, r, &payload) {
+		return
+	}
+
+	org, err := h.provisioning.UpdateOrganization(ctx, tenant.ID(), model.OrgID(r.PathValue("orgID")), service.UpdateOrganizationParams{
+		Name:              payload.Name,
+		Description:       payload.Description,
+		Active:            payload.Active,
+		Currency:          payload.Currency,
+		ShareQuotaEqually: payload.ShareQuotaEqually,
+	})
+	if err != nil {
+		writeServiceError(ctx, w, err, "organization not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, newOrganizationDTO(org))
+}
+
+func (h *Handler) handleDeleteOrganization(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.provisioning.DeleteOrganization(ctx, tenant.ID(), model.OrgID(r.PathValue("orgID"))); err != nil {
+		writeServiceError(ctx, w, err, "organization not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func toIdentityParams(payload userIdentityRequest) service.UserIdentityParams {
+	return service.UserIdentityParams{
+		Provider:    payload.Provider,
+		Subject:     payload.Subject,
+		Email:       payload.Email,
+		DisplayName: payload.DisplayName,
+		Active:      payload.Active,
+	}
+}

--- a/internal/provisionning/handler/v1/roles.go
+++ b/internal/provisionning/handler/v1/roles.go
@@ -10,9 +10,14 @@ import (
 func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	roles, err := h.provisioning.ListRoles(ctx, model.OrgID(r.PathValue("tenantID")))
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
+	roles, err := h.provisioning.ListRoles(ctx, org.ID())
 	if err != nil {
-		writeServiceError(ctx, w, err, "tenant not found")
+		writeServiceError(ctx, w, err, "organization not found")
 		return
 	}
 
@@ -30,12 +35,17 @@ func (h *Handler) handleListRoles(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	var payload roleRequest
 	if !decodeJSON(w, r, &payload) {
 		return
 	}
 
-	role, err := h.provisioning.CreateRole(ctx, model.OrgID(r.PathValue("tenantID")), service.RoleParams{
+	role, err := h.provisioning.CreateRole(ctx, org.ID(), service.RoleParams{
 		Name:        payload.Name,
 		Description: payload.Description,
 		Permissions: payload.Permissions,
@@ -52,8 +62,13 @@ func (h *Handler) handleCreateRole(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleGetRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	role, err := h.provisioning.GetRole(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.RoleID(r.PathValue("roleID")),
 	)
 	if err != nil {
@@ -67,13 +82,18 @@ func (h *Handler) handleGetRole(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	var payload roleRequest
 	if !decodeJSON(w, r, &payload) {
 		return
 	}
 
 	role, err := h.provisioning.UpdateRole(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.RoleID(r.PathValue("roleID")),
 		service.RoleParams{
 			Name:        payload.Name,
@@ -93,8 +113,13 @@ func (h *Handler) handleUpdateRole(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleDeleteRole(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	org, ok := h.resolveOrganization(w, r)
+	if !ok {
+		return
+	}
+
 	err := h.provisioning.DeleteRole(ctx,
-		model.OrgID(r.PathValue("tenantID")),
+		org.ID(),
 		model.RoleID(r.PathValue("roleID")),
 	)
 	if err != nil {

--- a/internal/provisionning/handler/v1/tenants.go
+++ b/internal/provisionning/handler/v1/tenants.go
@@ -3,30 +3,21 @@ package v1
 import (
 	"net/http"
 
+	"github.com/pkg/errors"
 	"github.com/xolo-gateway/xolo/internal/core/model"
 	"github.com/xolo-gateway/xolo/internal/core/port"
 	"github.com/xolo-gateway/xolo/internal/core/service"
-	"github.com/pkg/errors"
 )
-
-type createTenantResponse struct {
-	Tenant tenantDTO `json:"tenant"`
-
-	// Owner and Membership are present only when an initial owner was
-	// requested. OwnerCreated tells an external reconciler whether the identity
-	// already existed.
-	Owner        *userDTO       `json:"owner,omitempty"`
-	Membership   *membershipDTO `json:"ownerMembership,omitempty"`
-	OwnerCreated bool           `json:"ownerCreated"`
-}
 
 func (h *Handler) handleListTenants(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// An exact slug lookup lets a reconciler read back the state it just
-	// declared without knowing the generated identifier.
+	// declared without knowing the generated identifier. On a single-tenant
+	// instance it is also how a control plane discovers the tenant identifier
+	// every other route needs.
 	if slug := r.URL.Query().Get("slug"); slug != "" {
-		org, err := h.provisioning.GetTenantBySlug(ctx, slug)
+		tenant, err := h.provisioning.GetTenantBySlug(ctx, slug)
 		if err != nil {
 			if errors.Is(err, port.ErrNotFound) {
 				writeJSON(w, http.StatusOK, newListDTO([]tenantDTO{}, 1, 1, 0))
@@ -36,7 +27,7 @@ func (h *Handler) handleListTenants(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		writeJSON(w, http.StatusOK, newListDTO([]tenantDTO{newTenantDTO(org)}, 1, 1, 1))
+		writeJSON(w, http.StatusOK, newListDTO([]tenantDTO{newTenantDTO(tenant)}, 1, 1, 1))
 
 		return
 	}
@@ -49,20 +40,23 @@ func (h *Handler) handleListTenants(w http.ResponseWriter, r *http.Request) {
 
 	offset := page - 1
 
-	orgs, total, err := h.provisioning.ListTenants(ctx, port.ListOrgsOptions{Page: &offset, Limit: &limit})
+	tenants, total, err := h.provisioning.ListTenants(ctx, port.ListTenantsOptions{Page: &offset, Limit: &limit})
 	if err != nil {
 		writeServiceError(ctx, w, err, "could not list tenants")
 		return
 	}
 
-	items := make([]tenantDTO, 0, len(orgs))
-	for _, org := range orgs {
-		items = append(items, newTenantDTO(org))
+	items := make([]tenantDTO, 0, len(tenants))
+	for _, tenant := range tenants {
+		items = append(items, newTenantDTO(tenant))
 	}
 
 	writeJSON(w, http.StatusOK, newListDTO(items, page, limit, total))
 }
 
+// handleCreateTenant provisions a tenant. On a single-tenant instance the
+// service refuses it with a conflict: no hostname would ever resolve to the new
+// tenant, so its organizations would be unreachable.
 func (h *Handler) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -71,52 +65,27 @@ func (h *Handler) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := service.CreateTenantParams{
+	tenant, err := h.provisioning.CreateTenant(ctx, service.CreateTenantParams{
 		Slug:        payload.Slug,
 		Name:        payload.Name,
 		Description: payload.Description,
-		Currency:    payload.Currency,
 		Active:      payload.Active,
-	}
-
-	if payload.Owner != nil {
-		owner := toIdentityParams(*payload.Owner)
-		params.Owner = &owner
-	}
-
-	result, err := h.provisioning.CreateTenant(ctx, params)
+	})
 	if err != nil {
 		writeServiceError(ctx, w, err, "could not create tenant")
 		return
 	}
 
-	response := createTenantResponse{
-		Tenant:       newTenantDTO(result.Org),
-		OwnerCreated: result.OwnerCreated,
-	}
-
-	if result.Owner != nil {
-		owner := newUserDTO(result.Owner)
-		response.Owner = &owner
-	}
-	if result.OwnerMembership != nil {
-		membership := newMembershipDTO(result.OwnerMembership)
-		response.Membership = &membership
-	}
-
-	writeJSON(w, http.StatusCreated, response)
+	writeJSON(w, http.StatusCreated, newTenantDTO(tenant))
 }
 
 func (h *Handler) handleGetTenant(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	org, err := h.provisioning.GetTenant(ctx, model.OrgID(r.PathValue("tenantID")))
-	if err != nil {
-		writeServiceError(ctx, w, err, "tenant not found")
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, newTenantDTO(org))
+	writeJSON(w, http.StatusOK, newTenantDTO(tenant))
 }
 
 func (h *Handler) handleUpdateTenant(w http.ResponseWriter, r *http.Request) {
@@ -127,38 +96,26 @@ func (h *Handler) handleUpdateTenant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	org, err := h.provisioning.UpdateTenant(ctx, model.OrgID(r.PathValue("tenantID")), service.UpdateTenantParams{
-		Name:              payload.Name,
-		Description:       payload.Description,
-		Active:            payload.Active,
-		Currency:          payload.Currency,
-		ShareQuotaEqually: payload.ShareQuotaEqually,
+	tenant, err := h.provisioning.UpdateTenant(ctx, model.TenantID(r.PathValue("tenantID")), service.UpdateTenantParams{
+		Name:        payload.Name,
+		Description: payload.Description,
+		Active:      payload.Active,
 	})
 	if err != nil {
 		writeServiceError(ctx, w, err, "tenant not found")
 		return
 	}
 
-	writeJSON(w, http.StatusOK, newTenantDTO(org))
+	writeJSON(w, http.StatusOK, newTenantDTO(tenant))
 }
 
 func (h *Handler) handleDeleteTenant(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	if err := h.provisioning.DeleteTenant(ctx, model.OrgID(r.PathValue("tenantID"))); err != nil {
+	if err := h.provisioning.DeleteTenant(ctx, model.TenantID(r.PathValue("tenantID"))); err != nil {
 		writeServiceError(ctx, w, err, "tenant not found")
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func toIdentityParams(payload userIdentityRequest) service.UserIdentityParams {
-	return service.UserIdentityParams{
-		Provider:    payload.Provider,
-		Subject:     payload.Subject,
-		Email:       payload.Email,
-		DisplayName: payload.DisplayName,
-		Active:      payload.Active,
-	}
 }

--- a/internal/provisionning/handler/v1/users.go
+++ b/internal/provisionning/handler/v1/users.go
@@ -15,6 +15,11 @@ func (h *Handler) handleListUsers(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	query := r.URL.Query()
 
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
 	provider := strings.TrimSpace(query.Get("provider"))
 	subject := strings.TrimSpace(query.Get("subject"))
 
@@ -26,7 +31,7 @@ func (h *Handler) handleListUsers(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		user, err := h.provisioning.FindUserByIdentity(ctx, provider, subject)
+		user, err := h.provisioning.FindUserByIdentity(ctx, tenant.ID(), provider, subject)
 		if err != nil {
 			if errors.Is(err, port.ErrNotFound) {
 				writeJSON(w, http.StatusOK, newListDTO([]userDTO{}, 1, 1, 0))
@@ -61,11 +66,14 @@ func (h *Handler) handleListUsers(w http.ResponseWriter, r *http.Request) {
 
 	offset := page - 1
 
+	tenantID := tenant.ID()
+
 	users, total, err := h.provisioning.ListUsers(ctx, port.QueryUsersOptions{
-		Page:   &offset,
-		Limit:  &limit,
-		Search: query.Get("search"),
-		Active: active,
+		Page:     &offset,
+		Limit:    &limit,
+		Search:   query.Get("search"),
+		Active:   active,
+		TenantID: &tenantID,
 	})
 	if err != nil {
 		writeServiceError(ctx, w, err, "could not list users")
@@ -86,12 +94,17 @@ func (h *Handler) handleListUsers(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handlePutUser(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
 	var payload userIdentityRequest
 	if !decodeJSON(w, r, &payload) {
 		return
 	}
 
-	user, created, err := h.provisioning.ProvisionUser(ctx, toIdentityParams(payload))
+	user, created, err := h.provisioning.ProvisionUser(ctx, tenant.ID(), toIdentityParams(payload))
 	if err != nil {
 		writeServiceError(ctx, w, err, "could not provision user")
 		return
@@ -108,7 +121,12 @@ func (h *Handler) handlePutUser(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleGetUser(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	user, err := h.provisioning.GetUser(ctx, model.UserID(r.PathValue("userID")))
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
+	user, err := h.provisioning.GetUser(ctx, tenant.ID(), model.UserID(r.PathValue("userID")))
 	if err != nil {
 		writeServiceError(ctx, w, err, "user not found")
 		return
@@ -120,12 +138,17 @@ func (h *Handler) handleGetUser(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	tenant, ok := h.resolveTenant(w, r)
+	if !ok {
+		return
+	}
+
 	var payload updateUserRequest
 	if !decodeJSON(w, r, &payload) {
 		return
 	}
 
-	user, err := h.provisioning.UpdateUser(ctx, model.UserID(r.PathValue("userID")), service.UpdateUserParams{
+	user, err := h.provisioning.UpdateUser(ctx, tenant.ID(), model.UserID(r.PathValue("userID")), service.UpdateUserParams{
 		Email:       payload.Email,
 		DisplayName: payload.DisplayName,
 		Active:      payload.Active,

--- a/internal/setup/authn_token_handler.go
+++ b/internal/setup/authn_token_handler.go
@@ -19,7 +19,12 @@ func getTokenAuthnHandlerFromConfig(ctx context.Context, conf *config.Config) (*
 		return nil, errors.WithStack(err)
 	}
 
-	handler := token.NewHandler(sessionStore, userStore)
+	orgStore, err := getOrgStoreFromConfig(ctx, conf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	handler := token.NewHandler(sessionStore, userStore, orgStore)
 
 	return handler, nil
 }

--- a/internal/setup/http_server.go
+++ b/internal/setup/http_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xolo-gateway/xolo/internal/http/middleware/authn"
 	"github.com/xolo-gateway/xolo/internal/http/middleware/authz"
 	membershipsMiddleware "github.com/xolo-gateway/xolo/internal/http/middleware/memberships"
+	"github.com/xolo-gateway/xolo/internal/http/middleware/tenant"
 	"github.com/xolo-gateway/xolo/internal/http/middleware/ratelimit"
 	"github.com/pkg/errors"
 
@@ -253,9 +254,26 @@ func NewHTTPServerFromConfig(ctx context.Context, conf *config.Config) (*http.Se
 		return apiAuthnMiddleware(bridgeMiddleware(apiActiveCheck(withMemberships(h))))
 	}
 
+	tenantStore, err := getTenantStoreFromConfig(ctx, conf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// Tenant resolution wraps the whole server: authentication resolves a user
+	// within a tenant, so no route may run before the tenant is known. A host
+	// matching none answers 404 — an unknown subdomain must not reveal whether
+	// the instance exists.
+	tenantMiddleware := tenant.Middleware(
+		tenant.NewResolver(tenantStore, conf.Multitenancy),
+		gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+			common.HandleError(w, r, common.NewHTTPError(gohttp.StatusNotFound))
+		}),
+	)
+
 	options := []http.OptionFunc{
 		http.WithAddress(conf.HTTP.Address),
 		http.WithBaseURL(conf.HTTP.BaseURL),
+		http.WithMiddleware(tenantMiddleware),
 		http.WithMount("/assets/", assets),
 		http.WithMount("/assets/pipeline/", pipelineAssets.NewAssetsHandler()),
 		http.WithMount("/auth/oidc/", rateLimiter(oidcAuthn)),

--- a/internal/setup/provisioning_service.go
+++ b/internal/setup/provisioning_service.go
@@ -13,6 +13,11 @@ import (
 // decorators included. No second database connection, no second repository
 // implementation.
 var getProvisioningServiceFromConfig = createFromConfigOnce(func(ctx context.Context, conf *config.Config) (*service.ProvisioningService, error) {
+	tenantStore, err := getTenantStoreFromConfig(ctx, conf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
 	orgStore, err := getOrgStoreFromConfig(ctx, conf)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -31,7 +36,8 @@ var getProvisioningServiceFromConfig = createFromConfigOnce(func(ctx context.Con
 	// The default administrators are granted the platform admin role by the
 	// authentication bridge on sign-in: the API must not be able to hand one of
 	// those addresses to an arbitrary user.
-	return service.NewProvisioningService(orgStore, userStore, roleStore,
+	return service.NewProvisioningService(tenantStore, orgStore, userStore, roleStore,
 		service.WithReservedEmails(conf.HTTP.Authn.DefaultAdmins...),
+		service.WithMultiTenant(conf.Multitenancy.Enabled),
 	), nil
 })

--- a/internal/setup/tenant_store.go
+++ b/internal/setup/tenant_store.go
@@ -1,0 +1,17 @@
+package setup
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/xolo-gateway/xolo/internal/config"
+	"github.com/xolo-gateway/xolo/internal/core/port"
+)
+
+var getTenantStoreFromConfig = createFromConfigOnce(func(ctx context.Context, conf *config.Config) (port.TenantStore, error) {
+	store, err := getGormStoreFromConfig(ctx, conf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return store, nil
+})


### PR DESCRIPTION
## Contexte

Xolo cloisonnait ses données par organisation. Ça suffit pour une instance
dédiée, pas pour héberger plusieurs clients sur un même déploiement : le pool
d'utilisateurs était global (`users` unique sur `(provider, subject)`) et les
slugs d'organisation uniques à l'échelle de l'instance.

Cette PR ajoute un vrai niveau Tenant au-dessus de l'organisation.

## Comportement

| | Mono-tenant (défaut) | Multi-tenant |
| --- | --- | --- |
| Activation | Aucune | `XOLO_MULTITENANCY_ENABLED=true` |
| Résolution du tenant | Toujours `default` | Sous-domaine, selon `XOLO_MULTITENANCY_HOST_PATTERN` |
| Hôte inconnu | Sans objet | `404` |
| Sous-domaine requis | Non | Oui |
| URLs | Inchangées | Inchangées, sur le sous-domaine du tenant |
| Visible dans l'interface | Non | Non |
| Création de tenants | Refusée (`409`) | Via l'API de provisioning |
| Action à la mise à jour | Aucune | Aucune, puis activation quand souhaité |

La migration crée le tenant `default` et y rattache l'existant. Une instance
déjà déployée ne voit aucune différence.

## Isolation

Les utilisateurs appartiennent au tenant : l'unicité devient
`(tenant_id, provider, subject)`, donc une même identité OIDC sur deux tenants
donne deux comptes distincts. Les slugs d'organisation deviennent uniques par
tenant.

Les lookups par slug ou par identité prennent un `TenantID`. Les identifiants
xid restent globaux et la couche service vérifie le tenant. Le cache LRU des
utilisateurs intègre le tenant dans sa clé, `authn.Middleware` rejette une
session estampillée d'un autre tenant, et la console `/admin` se limite au
tenant courant. Un admin plateforme administre son tenant, plus l'instance
entière.

## Rupture : API de provisioning

Le vocabulaire était trompeur. `/v1/tenants` manipulait des organisations. J'ai
corrigé le nom et imbriqué les ressources selon la hiérarchie réelle.

| Avant | Après |
| --- | --- |
| `/v1/tenants` | `/v1/tenants/{tenantID}/organizations` |
| `/v1/tenants/{id}/members` | `/v1/tenants/{tenantID}/organizations/{orgID}/members` |
| `/v1/tenants/{id}/roles` | `/v1/tenants/{tenantID}/organizations/{orgID}/roles` |
| `/v1/users` | `/v1/tenants/{tenantID}/users` |

`/v1/tenants` désigne maintenant le vrai niveau tenant. Les utilisateurs passent
sous le tenant parce que `(provider, subject)` n'est plus une clé globale.

Un plan de contrôle existant récupère l'identifiant avec
`GET /v1/tenants?slug=default`, puis préfixe ses appels.

Deux garde-fous : `POST /v1/tenants` répond `409` tant que le multi-tenant est
désactivé, sinon on créerait un tenant qu'aucun hôte ne peut atteindre. Et le
tenant `default` ne peut être ni supprimé ni désactivé.

## Vérification

`go test ./...` (473 tests) et `make test-integration` sur SQLite et PostgreSQL
passent. Nouveaux tests : isolation croisée, cascade de suppression, migration
depuis un schéma pré-tenant, matching d'hôte, validation de configuration,
endpoints tenant.

Le test de migration a d'ailleurs attrapé deux vrais bugs : SQLite refuse un
`ADD COLUMN NOT NULL` sans défaut, et l'ancien index unique devait être
supprimé par son nom littéral, sinon GORM résolvait celui qui le remplace.

Vérifié à la main : mono-tenant transparent sur la fixture E2E, proxy LLM
compris ; 404 sur sous-domaine inconnu en multi-tenant ; et via l'API de
provisioning en mTLS, deux tenants portant chacun une organisation `acme` sans
collision, invisibles l'une de l'autre.

## Ce que je n'ai pas fait

Pas d'alias de compatibilité sur l'API M2M. La rupture est assumée.

Le test de migration depuis l'ancien schéma ne tourne que sur SQLite, comme le
`TestMigrateLegacyMembershipRoles` existant. Le chemin de mise à jour PostgreSQL
n'est donc pas couvert ; seule l'installation fraîche l'est. C'est ce que je
surveillerais en premier au déploiement.
