### PR TITLE
fix(webui): submit the model "enabled" switch with the form

### DIFF
--- a/internal/http/handler/webui/org/component/model_form.templ
+++ b/internal/http/handler/webui/org/component/model_form.templ
@@ -33,7 +33,7 @@ templ ModelForm(vmodel ModelFormVModel) {
 				})
 				if !vmodel.IsNew && vmodel.Model != nil {
 					@form.ItemFlex() {
-						@switchcomp.Switch(switchcomp.Props{ID: "enabled", Name: "enabled", Checked: vmodel.Model.Enabled(), Disabled: readonly})
+						@switchcomp.Switch(switchcomp.Props{ID: "enabled", Name: "enabled", Checked: vmodel.Model.Enabled(), Disabled: readonly, Form: "model-form"})
 						@form.Label(form.LabelProps{For: "enabled"}) {
 							Activé 
 						}
@@ -45,7 +45,7 @@ templ ModelForm(vmodel ModelFormVModel) {
 					{ vmodel.Error }
 				}
 			}
-			<form method="POST" action={ templ.SafeURL(action) } class="space-y-4">
+			<form id="model-form" method="POST" action={ templ.SafeURL(action) } class="space-y-4">
 				<!-- ── Ligne 1: Identité + Capacités (gauche, empilés) | Tarification + Estimation écologique (droite, empilés) ─── -->
 				<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
 					<!-- Cards gauche: Identité + Capacités (empilées) -->

--- a/internal/http/handler/webui/org/component/model_form_templ.go
+++ b/internal/http/handler/webui/org/component/model_form_templ.go
@@ -88,7 +88,7 @@ func ModelForm(vmodel ModelFormVModel) templ.Component {
 						}()
 					}
 					ctx = templ.InitializeContext(ctx)
-					templ_7745c5c3_Err = switchcomp.Switch(switchcomp.Props{ID: "enabled", Name: "enabled", Checked: vmodel.Model.Enabled(), Disabled: readonly}).Render(ctx, templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = switchcomp.Switch(switchcomp.Props{ID: "enabled", Name: "enabled", Checked: vmodel.Model.Enabled(), Disabled: readonly, Form: "model-form"}).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -158,14 +158,14 @@ func ModelForm(vmodel ModelFormVModel) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<form method=\"POST\" action=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<form id=\"model-form\" method=\"POST\" action=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 templ.SafeURL
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(action))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/handler/webui/org/component/model_form.templ`, Line: 48, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/http/handler/webui/org/component/model_form.templ`, Line: 48, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
The "Activé" switch on the model edit page sits in the page header, above the `<form>` that opens further down `model_form.templ`. A control outside a form is never submitted, so `updateModel` reads an always-empty field:

```go
enabled: r.FormValue("enabled") == "on",   // internal/http/handler/webui/org/providers.go
```

Every save therefore writes `enabled: false`, whatever the switch shows.

### How it surfaces

Both failure modes are silent — the redirect still reports `?success=updated`:

- **Editing any model disables it.** We hit this while filling in the pricing and ecological-estimation fields of a working model: it answered fine before the edit, and disappeared from `/v1/models` right after.
- **A disabled model cannot be brought back from the UI.** Toggling the switch and saving changes nothing, and recreating it is refused too, because `createModel` rejects a proxy name that the disabled row still holds. The only ways out are the database or a hand-crafted POST.

This also breaks any virtual model that embeds the disabled one, which fails with `could not resolve "<org>/<model>": model not available in organization`.

### Fix

The `Switch` component already supports the HTML `form` attribute, which associates a control with a form by id. Give the form an id and pass it — two lines, plus the regenerated `_templ.go`.

Verified that `form="model-form"` is rendered when the prop is set and that nothing is emitted when it is empty, so the other `Switch` call sites are unaffected. `go build ./...`, `go vet` and `go test ./internal/http/handler/webui/...` all pass.